### PR TITLE
lvm: force size in bytes to be written as integer.

### DIFF
--- a/curtin/commands/block_meta.py
+++ b/curtin/commands/block_meta.py
@@ -1318,7 +1318,7 @@ def lvm_partition_handler(info, storage_config):
 
         if info.get('size'):
             size = util.human2bytes(info["size"])
-            cmd.extend(["--size", "{}B".format(size)])
+            cmd.extend(["--size", "{}B".format(int(size))])
         else:
             cmd.extend(["--extents", "100%FREE"])
 


### PR DESCRIPTION
When using automatic install script in subiquity with automated size
computation, the output is a double with no decimal, but lvcreate
fails with values of bytes presenting a decimal point.