### PR TITLE
support older versions of iproute2

### DIFF
--- a/tools/find-tgt
+++ b/tools/find-tgt
@@ -35,6 +35,8 @@ for r in json.load(sys.stdin):
   print(r["dev"])
   break
 ')
+    # on bionic, ip -json route show doesn't produce json
+    [ -n "$dev" ] || dev=$(ip route show | grep ^default | awk '{print $5}')
     [ -n "$dev" ] || { error "failed to find ipv4 device"; return 1; }
     addr=$(ip addr show dev "$dev" |
         awk '$1 == "inet" {gsub(/\/.*/,"", $2); print $2; exit}')


### PR DESCRIPTION
In https://github.com/canonical/curtin/commit/d986f0072, `tools/find-tgt` was updated to use iproute2. Unfortunately, on Bionic currently `ip -json route show` does not actually produce json, so we are seeing [failures in a Jenkins test](https://jenkins.canonical.com/server-team/view/cloud-init/job/curtin-cloud-init-sru/6/console).

Seen in a test recently:
```
13:12:22 Traceback (most recent call last):
13:12:22   File "<string>", line 2, in <module>
13:12:22   File "/usr/lib/python3.6/json/__init__.py", line 299, in load
13:12:22     parse_constant=parse_constant, object_pairs_hook=object_pairs_hook, **kw)
13:12:22   File "/usr/lib/python3.6/json/__init__.py", line 354, in loads
13:12:22     return _default_decoder.decode(s)
13:12:22   File "/usr/lib/python3.6/json/decoder.py", line 339, in decode
13:12:22     obj, end = self.raw_decode(s, idx=_w(s, 0).end())
13:12:22   File "/usr/lib/python3.6/json/decoder.py", line 357, in raw_decode
13:12:22     raise JSONDecodeError("Expecting value", s, err.value) from None
13:12:22 json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)
13:12:22 failed to find ipv4 device
```