### PR TITLE
Add support for partitions directly on dm-crypt devices (no LVM)

### DIFF
--- a/curtin/storage_config.py
+++ b/curtin/storage_config.py
@@ -212,7 +212,7 @@ def _validate_dep_type(source_id, dep_key, dep_id, sconfig):
         'lvm_partition': {'lvm_volgroup'},
         'lvm_volgroup': {'bcache', 'disk', 'dm_crypt', 'partition', 'raid'},
         'mount': {'format'},
-        'partition': {'bcache', 'disk', 'raid', 'partition'},
+        'partition': {'bcache', 'disk', 'dm_crypt', 'raid', 'partition'},
         'raid': {'bcache', 'disk', 'dm_crypt', 'lvm_partition',
                  'partition', 'raid'},
         'zfs': {'zpool'},


### PR DESCRIPTION
This configuration is possible - it was even [proposed a few years ago](https://discourse.ubuntu.com/t/full-disk-encryption-without-lvm-by-default-call-for-comments/18937) as the default configuration for Ubuntu Desktop / Server, though that proposal never garnered enough support for adoption. 