### PR TITLE
Add dracut invocation to suse disk provisioning

### DIFF
--- a/curtin/commands/install_grub.py
+++ b/curtin/commands/install_grub.py
@@ -329,6 +329,7 @@ def gen_uefi_install_commands(grub_name, grub_target, grub_cmd, update_nvram,
                                      '--loader',
                                      efi_loader_esp_path(loader)])
         post_cmds.append(['grub2-mkconfig', '-o', grub_cfg])
+        post_cmds.append(['dracut', '--force', '--kver', '$(ls /lib/modules)'])
     else:
         raise ValueError("Unsupported os family for grub "
                          "install: %s" % distroinfo.family)


### PR DESCRIPTION
Dracut makes the formatted partition 2 findable by the bootloader.  Otherwise the bootloader is stuck forever, waiting for a disk to be mounted and to appear. 

The kver is the version of the kernel found inside the OS that's being loades (the in-target OS).  Format is something like '5.14.21-150500-55.28-default'.