### PR TITLE
Fix the "security" structure in examples/apt-source.yaml

### DIFF
--- a/examples/apt-source.yaml
+++ b/examples/apt-source.yaml
@@ -99,8 +99,9 @@ apt:
       # as above, allowing to have one config for different per arch mirrors
   # security is optional, if not defined it is set to the same value as primary
   security:
-    uri: http://security.ubuntu.com/ubuntu
-    # [...]
+    - arches: [amd64, i386, default]
+      uri: http://security.ubuntu.com/ubuntu
+      # [...]
 
   # if no mirrors are specified at all, or all lookups fail it will use:
   # primary: http://archive.ubuntu.com/ubuntu


### PR DESCRIPTION
The `security` in examples/apt-source.yaml needs `arch` like `primary`, too.

Actually, the content of /var/log/installer/subiquity-curtin-apt.conf generated by manual installation for Ubuntu 22.04.4 is  below:
```
# Autogenerated by Subiquity: 2024-03-19 15:39:12.974186 UTC
apt:
  debconf_selections:
    subiquity: ''
  disable_components: []
  preserve_sources_list: false
  primary:
  - arches:
    - default
    uri: http://jp.archive.ubuntu.com/ubuntu/
  security:
  - arches:
    - amd64
    - i386
    uri: http://security.ubuntu.com/ubuntu/
  - arches:
    - s390x
    - arm64
    - armhf
    - powerpc
    - ppc64el
    - riscv64
    uri: http://ports.ubuntu.com/ubuntu-ports
```