### PR TITLE
Make shutdown_lvm work with thin-pools - allows to install over proxmox

### DIFF
--- a/curtin/block/clear_holders.py
+++ b/curtin/block/clear_holders.py
@@ -136,9 +136,13 @@ def shutdown_lvm(device):
     # (corresponding to the "lv_dm_path" property), let's use this one instead.
     dm_path = os.path.join("/dev/mapper/", lvm_name)
 
-    # wipe contents of the logical volume first
-    LOG.info('Wiping lvm logical volume: %s (%s)', dm_path, vg_lv_name)
-    block.quick_zero(dm_path, partitions=False)
+    if util.load_file(os.path.join(device, 'ro')).strip() == '0':
+        # wipe contents of the logical volume first
+        LOG.info('Wiping lvm logical volume: %s (%s)', dm_path, vg_lv_name)
+        block.quick_zero(dm_path, partitions=False)
+    else:
+        LOG.info("%s (%s) is read-only, skipping attempt to wipe device",
+                 dm_path, vg_lv_name)
 
     # remove the logical volume
     LOG.debug('using "lvremove" on %s', vg_lv_name)

--- a/curtin/block/clear_holders.py
+++ b/curtin/block/clear_holders.py
@@ -127,11 +127,18 @@ def shutdown_lvm(device):
     lvm_name = util.load_file(name_file).strip()
     (vg_name, lv_name) = lvm.split_lvm_name(lvm_name)
     vg_lv_name = "%s/%s" % (vg_name, lv_name)
-    devname = "/dev/" + vg_lv_name
+
+    # Normal LV-s have a symlink in /dev/{vgname}/{lvname} which corresponds to
+    # the "lv_path" property. This path is what we previously used for wiping.
+    # However, other types of LV-s (such as thin-pools) don't have this
+    # symlink.
+    # Since both types of LV have a /dev/mapper/{vgname}-{lvname} symlink
+    # (corresponding to the "lv_dm_path" property), let's use this one instead.
+    dm_path = os.path.join("/dev/mapper/", lvm_name)
 
     # wipe contents of the logical volume first
-    LOG.info('Wiping lvm logical volume: %s', devname)
-    block.quick_zero(devname, partitions=False)
+    LOG.info('Wiping lvm logical volume: %s (%s)', dm_path, vg_lv_name)
+    block.quick_zero(dm_path, partitions=False)
 
     # remove the logical volume
     LOG.debug('using "lvremove" on %s', vg_lv_name)

--- a/tests/unittests/test_clear_holders.py
+++ b/tests/unittests/test_clear_holders.py
@@ -182,8 +182,8 @@ class TestClearHolders(CiTestCase):
         lvm_name = 'ubuntu--vg-swap'
         vg_name = 'ubuntu-vg'
         lv_name = 'swap'
-        vg_lv_name = "%s/%s" % (vg_name, lv_name)
-        devname = "/dev/" + vg_lv_name
+        vg_lv_name = "ubuntu-vg/swap"
+        dm_path = "/dev/mapper/ubuntu--vg-swap"
         pvols = ['/dev/wda1', '/dev/wda2']
         mock_syspath.return_value = self.test_blockdev
         mock_util.load_file.return_value = lvm_name
@@ -192,7 +192,7 @@ class TestClearHolders(CiTestCase):
         clear_holders.shutdown_lvm(self.test_blockdev)
         mock_syspath.assert_called_with(self.test_blockdev)
         mock_util.load_file.assert_called_with(self.test_blockdev + '/dm/name')
-        mock_zero.assert_called_with(devname, partitions=False)
+        mock_zero.assert_called_with(dm_path, partitions=False)
         mock_lvm.split_lvm_name.assert_called_with(lvm_name.strip())
         self.assertTrue(mock_log.debug.called)
         mock_util.subp.assert_called_with(

--- a/tests/unittests/test_clear_holders.py
+++ b/tests/unittests/test_clear_holders.py
@@ -186,12 +186,17 @@ class TestClearHolders(CiTestCase):
         dm_path = "/dev/mapper/ubuntu--vg-swap"
         pvols = ['/dev/wda1', '/dev/wda2']
         mock_syspath.return_value = self.test_blockdev
-        mock_util.load_file.return_value = lvm_name
+        mock_util.load_file.side_effect = (lvm_name, '0\n')
         mock_lvm.split_lvm_name.return_value = (vg_name, lv_name)
         mock_lvm.get_lvols_in_volgroup.return_value = ['lvol2']
         clear_holders.shutdown_lvm(self.test_blockdev)
         mock_syspath.assert_called_with(self.test_blockdev)
-        mock_util.load_file.assert_called_with(self.test_blockdev + '/dm/name')
+        expected_load_file_calls = [
+            mock.call(self.test_blockdev + '/dm/name'),
+            mock.call(self.test_blockdev + '/ro'),
+        ]
+        self.assertEqual(expected_load_file_calls,
+                         mock_util.load_file.mock_calls)
         mock_zero.assert_called_with(dm_path, partitions=False)
         mock_lvm.split_lvm_name.assert_called_with(lvm_name.strip())
         self.assertTrue(mock_log.debug.called)
@@ -201,12 +206,46 @@ class TestClearHolders(CiTestCase):
         self.assertEqual(len(mock_util.subp.call_args_list), 1)
         mock_lvm.get_lvols_in_volgroup.return_value = []
         self.assertTrue(mock_lvm.lvm_scan.called)
+        mock_util.load_file.side_effect = (lvm_name, '0\n')
         mock_lvm.get_pvols_in_volgroup.return_value = pvols
         clear_holders.shutdown_lvm(self.test_blockdev)
         mock_util.subp.assert_called_with(
             ['vgremove', '--force', '--force', vg_name], rcs=[0, 5])
         for pv in pvols:
             mock_zero.assert_any_call(pv, partitions=False)
+        self.assertTrue(mock_lvm.lvm_scan.called)
+
+    @mock.patch('curtin.block.quick_zero')
+    @mock.patch('curtin.block.clear_holders.LOG')
+    @mock.patch('curtin.block.clear_holders.block.sys_block_path')
+    @mock.patch('curtin.block.clear_holders.lvm')
+    @mock.patch('curtin.block.clear_holders.util')
+    def test_shutdown_lvm__thin_pool(self, mock_util, mock_lvm, mock_syspath,
+                                     mock_log, mock_zero):
+        """test clear_holders.shutdown_lvm when given a thin pool"""
+        lvm_name = 'pve-data'
+        vg_name = 'pve'
+        lv_name = 'data'
+        vg_lv_name = "pve/data"
+        mock_syspath.return_value = self.test_blockdev
+        mock_util.load_file.side_effect = (lvm_name, '1\n')
+        mock_lvm.split_lvm_name.return_value = (vg_name, lv_name)
+        mock_lvm.get_lvols_in_volgroup.return_value = ['lvol2']
+        clear_holders.shutdown_lvm(self.test_blockdev)
+        mock_syspath.assert_called_with(self.test_blockdev)
+        expected_load_file_calls = [
+            mock.call(self.test_blockdev + '/dm/name'),
+            mock.call(self.test_blockdev + '/ro'),
+        ]
+        self.assertEqual(expected_load_file_calls,
+                         mock_util.load_file.mock_calls)
+        # We skipped it because the device is read-only
+        mock_zero.assert_not_called()
+        mock_lvm.split_lvm_name.assert_called_with(lvm_name.strip())
+        self.assertTrue(mock_log.debug.called)
+        mock_util.subp.assert_called_with(
+            ['lvremove', '--force', '--force', vg_lv_name])
+        mock_util.subp.assert_called_once()
         self.assertTrue(mock_lvm.lvm_scan.called)
 
     @mock.patch('curtin.block.clear_holders.block')

--- a/tests/unittests/test_clear_holders.py
+++ b/tests/unittests/test_clear_holders.py
@@ -179,7 +179,7 @@ class TestClearHolders(CiTestCase):
     def test_shutdown_lvm(self, mock_util, mock_lvm, mock_syspath, mock_log,
                           mock_zero):
         """test clear_holders.shutdown_lvm"""
-        lvm_name = b'ubuntu--vg-swap\n'
+        lvm_name = 'ubuntu--vg-swap'
         vg_name = 'ubuntu-vg'
         lv_name = 'swap'
         vg_lv_name = "%s/%s" % (vg_name, lv_name)


### PR DESCRIPTION
A thin-pool, compared to a normal LVM logical group has the following properties:

* it is not exist under `/dev/{vgname}/{lvname}` (i.e., its `"lv_path"` property is set to `""`)
* it is read-only so `wipefs` would return `Permission denied`

Instead of using what's normally in the `"lv_path"` property, we now use the `"lv_dm_path"` property (i.e., `/dev/mapper/{vgname}-{lvname}`). It still exists for normal LVs.

Also, we now check if a block device is read-only before running the wipefs operation, so we don't end up failing for thin-pools.

LP:#2107256