### PR TITLE
apt-config: pull arm64 from archive.ubuntu.com starting Ubuntu 25.10

### DIFF
--- a/curtin/commands/apt_config.py
+++ b/curtin/commands/apt_config.py
@@ -41,8 +41,6 @@ PRIMARY_ARCH_MIRRORS = {"PRIMARY": "http://archive.ubuntu.com/ubuntu/",
                         "SECURITY": "http://security.ubuntu.com/ubuntu/"}
 PORTS_MIRRORS = {"PRIMARY": "http://ports.ubuntu.com/ubuntu-ports",
                  "SECURITY": "http://ports.ubuntu.com/ubuntu-ports"}
-PRIMARY_ARCHES = ['amd64', 'i386']
-PORTS_ARCHES = ['s390x', 'arm64', 'armhf', 'powerpc', 'ppc64el', 'riscv64']
 
 APT_SOURCES_PROPOSED = (
     "deb $MIRROR $RELEASE-proposed main restricted universe multiverse")
@@ -56,15 +54,36 @@ APT_SOURCES_PROPOSED_DEB822 = (
 )
 
 
-def get_default_mirrors(arch=None):
+default_arches = {
+    "primary": {"amd64", "i386"},
+    "ports": {"s390x", "arm64", "armhf", "powerpc", "ppc64el", "riscv64"},
+}
+
+
+def _get_arches(os_release: dict[str, str], *, key: str) -> set[str]:
+    if os_release.get("ID") != "ubuntu":
+        return default_arches[key]
+    # TODO
+    return default_arches[key]
+
+
+def get_primary_arches(os_release: dict[str, str]) -> set[str]:
+    return _get_arches(os_release, key="primary")
+
+
+def get_ports_arches(os_release: dict[str, str]) -> set[str]:
+    return _get_arches(os_release, key="ports")
+
+
+def get_default_mirrors(arch=None, *, os_release):
     """returns the default mirrors for the target. These depend on the
-       architecture, for more see:
+       architecture and the release being installed, for more see:
        https://wiki.ubuntu.com/UbuntuDevelopment/PackageArchive#Ports"""
     if arch is None:
         arch = distro.get_architecture()
-    if arch in PRIMARY_ARCHES:
+    if arch in get_primary_arches(os_release):
         return PRIMARY_ARCH_MIRRORS.copy()
-    if arch in PORTS_ARCHES:
+    if arch in get_ports_arches(os_release):
         return PORTS_MIRRORS.copy()
     raise ValueError("No default mirror known for arch %s" % arch)
 
@@ -184,16 +203,16 @@ def deb822_entry_to_str(entry):
     return stanza
 
 
-def maybe_convert_sources_to_deb822(sources):
+def maybe_convert_sources_to_deb822(sources, target):
     try:
         parse_deb822_sources(sources)
 
         return sources
     except Deb822SourceFormatException:
-        return convert_sources_to_deb822(sources)
+        return convert_sources_to_deb822(sources, target=target)
 
 
-def convert_sources_to_deb822(sources):
+def convert_sources_to_deb822(sources, target):
     index = {}
 
     for entry in [SourceEntry(e) for e in sources.splitlines(True)]:
@@ -246,7 +265,8 @@ def convert_sources_to_deb822(sources):
                 del index[ks]
 
     # Add Signed-By field if URI is default or will render to a configured one.
-    mirrors = list(get_default_mirrors().values())
+    mirrors = list(get_default_mirrors(
+            os_release=distro.os_release(target)).values())
     mirrors += [m.rstrip('/') for m in mirrors]
     mirrors += ['$MIRROR', '$SECURITY', '$PRIMARY']
 
@@ -270,7 +290,8 @@ def handle_apt(cfg, target=None):
     """
     release = distro.lsb_release(target=target)['codename']
     arch = distro.get_architecture(target)
-    mirrors = find_apt_mirror_info(cfg, arch)
+    mirrors = find_apt_mirror_info(
+        cfg, arch, os_release=distro.os_release(target))
     LOG.debug("Apt Mirror info: %s", mirrors)
 
     apply_debconf_selections(cfg, target)
@@ -403,7 +424,8 @@ def rename_apt_lists(new_mirrors, target=None, arch=None):
     """rename_apt_lists - rename apt lists to preserve old cache data"""
     if arch is None:
         arch = distro.get_architecture(target)
-    default_mirrors = get_default_mirrors(arch)
+    default_mirrors = get_default_mirrors(
+        arch, os_release=distro.os_release(target))
 
     pre = paths.target_path(target, APT_LISTS)
     for (name, omirror) in default_mirrors.items():
@@ -429,7 +451,7 @@ def rename_apt_lists(new_mirrors, target=None, arch=None):
 def make_mirrors_replacement(mirrors, target, arch=None):
     if arch is None:
         arch = distro.get_architecture(target)
-    defaults = get_default_mirrors(arch)
+    defaults = get_default_mirrors(arch, os_release=distro.os_release(target))
     mirrors_replacement = {}
 
     uri = mirrors.get('MIRROR')
@@ -603,7 +625,7 @@ def _generate_sources_deb822(cfg, release, mirrors, target=None, arch=None):
         from_file = True
 
     # Convert to deb822 sources if needed.
-    tmpl = maybe_convert_sources_to_deb822(tmpl)
+    tmpl = maybe_convert_sources_to_deb822(tmpl, target=target)
 
     suites_to_disable = set()
     if cfg.get('disable_suites') is not None:
@@ -788,7 +810,7 @@ def add_apt_sources(srcdict, target=None, template_params=None,
 
         # Convert this source to deb822 format if needed.
         if target_wants_deb822:
-            source = maybe_convert_sources_to_deb822(source)
+            source = maybe_convert_sources_to_deb822(source, target)
 
         ext = '.sources' if target_wants_deb822 else '.list'
         splext = os.path.splitext(ent['filename'])
@@ -827,7 +849,7 @@ def search_for_mirror(candidates):
     return None
 
 
-def update_mirror_info(pmirror, smirror, arch):
+def update_mirror_info(pmirror, smirror, arch, os_release):
     """sets security mirror to primary if not defined.
        returns defaults if no mirrors are defined"""
     if pmirror is not None:
@@ -835,7 +857,7 @@ def update_mirror_info(pmirror, smirror, arch):
             smirror = pmirror
         return {'PRIMARY': pmirror,
                 'SECURITY': smirror}
-    return get_default_mirrors(arch)
+    return get_default_mirrors(arch, os_release=os_release)
 
 
 def get_arch_mirrorconfig(cfg, mirrortype, arch):
@@ -876,7 +898,7 @@ def get_mirror(cfg, mirrortype, arch):
     return mirror
 
 
-def find_apt_mirror_info(cfg, arch=None):
+def find_apt_mirror_info(cfg, arch=None, *, os_release):
     """find_apt_mirror_info
        find an apt_mirror given the cfg provided.
        It can check for separate config of primary and security mirrors
@@ -894,7 +916,7 @@ def find_apt_mirror_info(cfg, arch=None):
 
     # Note: curtin has no cloud-datasource fallback
 
-    mirror_info = update_mirror_info(pmirror, smirror, arch)
+    mirror_info = update_mirror_info(pmirror, smirror, arch, os_release)
 
     # less complex replacements use only MIRROR, derive from primary
     mirror_info["MIRROR"] = mirror_info["PRIMARY"]

--- a/curtin/commands/apt_config.py
+++ b/curtin/commands/apt_config.py
@@ -58,12 +58,25 @@ default_arches = {
     "primary": {"amd64", "i386"},
     "ports": {"s390x", "arm64", "armhf", "powerpc", "ppc64el", "riscv64"},
 }
+# Since Ubuntu 25.10, arm64 is served on the primary mirror.
+ubuntu_ge_25_10_arches = {
+    "primary": {"amd64", "i386", "arm64"},
+    "ports": {"s390x", "armhf", "powerpc", "ppc64el", "riscv64"},
+}
 
 
 def _get_arches(os_release: dict[str, str], *, key: str) -> set[str]:
     if os_release.get("ID") != "ubuntu":
         return default_arches[key]
-    # TODO
+
+    ubuntu_version = os_release["VERSION_ID"].split(".")
+
+    major = int(ubuntu_version[0])
+    minor = int(ubuntu_version[1])
+
+    if major >= 26 or (major == 25 and minor >= 10):
+        return ubuntu_ge_25_10_arches[key]
+
     return default_arches[key]
 
 

--- a/curtin/commands/apt_config.py
+++ b/curtin/commands/apt_config.py
@@ -91,7 +91,8 @@ def get_ports_arches(os_release: dict[str, str]) -> set[str]:
 def get_default_mirrors(arch=None, *, os_release):
     """returns the default mirrors for the target. These depend on the
        architecture and the release being installed, for more see:
-       https://wiki.ubuntu.com/UbuntuDevelopment/PackageArchive#Ports"""
+       https://documentation.ubuntu.com/project/how-ubuntu-is-made/concepts/supported-architectures/
+    """  # noqa
     if arch is None:
         arch = distro.get_architecture()
     if arch in get_primary_arches(os_release):

--- a/tests/unittests/test_apt_custom_sources_list.py
+++ b/tests/unittests/test_apt_custom_sources_list.py
@@ -212,16 +212,20 @@ class TestAptSourceConfigSourceList(CiTestCase):
         with mock.patch.object(distro, 'get_architecture', return_value=arch):
             with mock.patch.object(distro, 'lsb_release',
                                    return_value={'codename': 'fakerel'}):
-                apt_config.handle_apt(cfg, target)
+                with mock.patch.object(distro, 'os_release',
+                                       return_value={'ID': 'not-ubuntu'}):
+                    apt_config.handle_apt(cfg, target)
 
         self.assertEqual(
             EXPECTED_CONVERTED_CONTENT,
             util.load_file(paths.target_path(target, "/etc/apt/sources.list")))
 
     @mock_want_deb822(False)
+    @mock.patch("curtin.distro.os_release")
     @mock.patch("curtin.distro.lsb_release")
     @mock.patch("curtin.distro.get_architecture", return_value="amd64")
-    def test_trusty_source_lists(self, m_get_arch, m_lsb_release):
+    def test_trusty_source_lists(
+            self, m_get_arch, m_lsb_release, m_os_release):
         """Support mirror equivalency with and without trailing /.
 
         Trusty official images do not have a trailing slash on
@@ -238,6 +242,9 @@ class TestAptSourceConfigSourceList(CiTestCase):
         m_lsb_release.return_value = {
             'codename': 'trusty', 'description': 'Ubuntu 14.04.5 LTS',
             'id': 'Ubuntu', 'release': '14.04'}
+        m_os_release.return_value = {
+            'ID': 'ubuntu', 'VERSION_ID': '14.04',
+        }
 
         target = self.new_root
         my_primary = 'http://fixed-primary.ubuntu.com/ubuntu'
@@ -298,7 +305,9 @@ class TestAptSourceConfigSourceList(CiTestCase):
             ):
                 with mock.patch.object(distro, 'lsb_release',
                                        return_value={'codename': 'fakerel'}):
-                    apt_config.handle_apt(cfg, target)
+                    with mock.patch.object(distro, 'os_release',
+                                           return_value={'ID': 'not-ubuntu'}):
+                        apt_config.handle_apt(cfg, target)
 
             self.assertEqual(
                 EXPECTED_CONVERTED_CONTENT_DEB822,

--- a/tests/unittests/test_apt_source.py
+++ b/tests/unittests/test_apt_source.py
@@ -20,6 +20,8 @@ from curtin import util
 from curtin.commands import apt_config
 from .helpers import CiTestCase
 
+from parameterized import parameterized
+
 
 EXPECTEDKEY = u"""-----BEGIN PGP PUBLIC KEY BLOCK-----
 Version: GnuPG v1
@@ -102,6 +104,33 @@ def mock_want_deb822(return_value):
     return inner
 
 
+class TestGetArches(CiTestCase):
+    @parameterized.expand(
+        (
+            (
+             {"ID": "ubuntu", "VERSION_ID": "22.04"},
+             {"amd64", "i386"}),
+            ({"ID": "ubuntu", "VERSION_ID": "24.04"},
+             {"amd64", "i386"}),
+        ),
+    )
+    def test_primary(self, os_release, expected_arches):
+        self.assertEqual(expected_arches,
+                         apt_config.get_primary_arches(os_release=os_release))
+
+    @parameterized.expand(
+        (
+            ({"ID": "ubuntu", "VERSION_ID": "22.04"},
+             {"s390x", "arm64", "armhf", "powerpc", "ppc64el", "riscv64"}),
+            ({"ID": "ubuntu", "VERSION_ID": "24.04"},
+             {"s390x", "arm64", "armhf", "powerpc", "ppc64el", "riscv64"}),
+        ),
+    )
+    def test_ports(self, os_release, expected_arches):
+        self.assertEqual(expected_arches,
+                         apt_config.get_ports_arches(os_release=os_release))
+
+
 class TestAptSourceConfig(CiTestCase):
     """ TestAptSourceConfig
     Main Class to test apt configs
@@ -109,6 +138,7 @@ class TestAptSourceConfig(CiTestCase):
     def setUp(self):
         super(TestAptSourceConfig, self).setUp()
         self.target = self.tmp_dir()
+        self.os_release = {'ID': 'ubuntu', 'VERSION_ID': '24.04'}
         self.aptlistfile = "single-deb.list"
         self.aptlistfile2 = "single-deb2.list"
         self.aptlistfile3 = "single-deb3.list"
@@ -138,8 +168,10 @@ class TestAptSourceConfig(CiTestCase):
         params = {}
         params['RELEASE'] = distro.lsb_release()['codename']
         arch = distro.get_architecture()
-        params['MIRROR'] = apt_config.get_default_mirrors(arch)["PRIMARY"]
-        params['SECURITY'] = apt_config.get_default_mirrors(arch)["SECURITY"]
+        mirrors = apt_config.get_default_mirrors(
+            arch, os_release={'ID': 'ubuntu', 'VERSION_ID': '26.04'})
+        params['MIRROR'] = mirrors['PRIMARY']
+        params['SECURITY'] = mirrors['SECURITY']
         return params
 
     def _apt_src_basic(self, filename, cfg):
@@ -582,7 +614,8 @@ class TestAptSourceConfig(CiTestCase):
         fromfn = ("%s/%s_%s" % (pre, archive, post))
         tofn = ("%s/test.ubuntu.com_%s" % (pre, post))
 
-        mirrors = apt_config.find_apt_mirror_info(cfg, arch)
+        mirrors = apt_config.find_apt_mirror_info(
+            cfg, arch, os_release=self.os_release)
 
         self.assertEqual(mirrors['MIRROR'],
                          "http://test.ubuntu.com/%s/" % component)
@@ -762,7 +795,8 @@ Pin-Priority: -1
                "security": [{'arches': ["default"],
                              "uri": smir}]}
 
-        mirrors = apt_config.find_apt_mirror_info(cfg, 'amd64')
+        mirrors = apt_config.find_apt_mirror_info(
+                cfg, 'amd64', os_release=self.os_release)
 
         self.assertEqual(mirrors['MIRROR'],
                          pmir)
@@ -774,10 +808,12 @@ Pin-Priority: -1
     def test_mirror_default(self):
         """test_mirror_default - Test without defining a mirror"""
         arch = distro.get_architecture()
-        default_mirrors = apt_config.get_default_mirrors(arch)
+        default_mirrors = apt_config.get_default_mirrors(
+                arch, os_release=self.os_release)
         pmir = default_mirrors["PRIMARY"]
         smir = default_mirrors["SECURITY"]
-        mirrors = apt_config.find_apt_mirror_info({}, arch)
+        mirrors = apt_config.find_apt_mirror_info(
+                {}, arch, os_release=self.os_release)
 
         self.assertEqual(mirrors['MIRROR'],
                          pmir)
@@ -796,7 +832,8 @@ Pin-Priority: -1
                "security": [{'arches': ["default"], "uri": "nothis-security"},
                             {'arches': [arch], "uri": smir}]}
 
-        mirrors = apt_config.find_apt_mirror_info(cfg, arch)
+        mirrors = apt_config.find_apt_mirror_info(
+                cfg, arch, os_release=self.os_release)
 
         self.assertEqual(mirrors['PRIMARY'], pmir)
         self.assertEqual(mirrors['MIRROR'], pmir)
@@ -815,7 +852,8 @@ Pin-Priority: -1
                             {'arches': ["default"],
                              "uri": smir}]}
 
-        mirrors = apt_config.find_apt_mirror_info(cfg, 'amd64')
+        mirrors = apt_config.find_apt_mirror_info(
+                cfg, 'amd64', os_release=self.os_release)
 
         self.assertEqual(mirrors['MIRROR'],
                          pmir)
@@ -830,10 +868,12 @@ Pin-Priority: -1
         m_get_architecture.return_value = arch
         expected = {'PRIMARY': 'http://ports.ubuntu.com/ubuntu-ports',
                     'SECURITY': 'http://ports.ubuntu.com/ubuntu-ports'}
-        self.assertEqual(expected, apt_config.get_default_mirrors())
+        self.assertEqual(expected, apt_config.get_default_mirrors(
+                    os_release=distro.os_release(self.target)))
 
     def test_get_default_mirrors_non_intel_with_arch(self):
-        found = apt_config.get_default_mirrors('ppc64el')
+        found = apt_config.get_default_mirrors(
+                'ppc64el', os_release=distro.os_release(self.target))
 
         expected = {'PRIMARY': 'http://ports.ubuntu.com/ubuntu-ports',
                     'SECURITY': 'http://ports.ubuntu.com/ubuntu-ports'}
@@ -842,7 +882,8 @@ Pin-Priority: -1
     def test_mirror_arches_sysdefault(self):
         """test_mirror_arches - Test arches falling back to sys default"""
         arch = distro.get_architecture()
-        default_mirrors = apt_config.get_default_mirrors(arch)
+        default_mirrors = apt_config.get_default_mirrors(
+                arch, os_release=distro.os_release(self.target))
         pmir = default_mirrors["PRIMARY"]
         smir = default_mirrors["SECURITY"]
         cfg = {"primary": [{'arches': ["thisarchdoesntexist_64"],
@@ -854,7 +895,8 @@ Pin-Priority: -1
                             {'arches': ["thisarchdoesntexist_64"],
                              "uri": "nothateither"}]}
 
-        mirrors = apt_config.find_apt_mirror_info(cfg, arch)
+        mirrors = apt_config.find_apt_mirror_info(
+                cfg, arch, os_release=self.os_release)
 
         self.assertEqual(mirrors['MIRROR'], pmir)
         self.assertEqual(mirrors['PRIMARY'], pmir)
@@ -872,7 +914,8 @@ Pin-Priority: -1
 
         with mock.patch.object(apt_config, 'search_for_mirror',
                                side_effect=[pmir, smir]) as mocksearch:
-            mirrors = apt_config.find_apt_mirror_info(cfg, 'amd64')
+            mirrors = apt_config.find_apt_mirror_info(
+                    cfg, 'amd64', os_release=self.os_release)
 
         calls = [call(["pfailme", pmir]),
                  call(["sfailme", smir])]
@@ -901,13 +944,15 @@ Pin-Priority: -1
         # should be called only once per type, despite two mirror configs
         with mock.patch.object(apt_config, 'get_mirror',
                                return_value="http://mocked/foo") as mockgm:
-            mirrors = apt_config.find_apt_mirror_info(cfg, arch)
+            mirrors = apt_config.find_apt_mirror_info(
+                    cfg, arch, os_release=self.os_release)
         calls = [call(cfg, 'primary', arch), call(cfg, 'security', arch)]
         mockgm.assert_has_calls(calls)
 
         # should not be called, since primary is specified
         with mock.patch.object(apt_config, 'search_for_mirror') as mockse:
-            mirrors = apt_config.find_apt_mirror_info(cfg, arch)
+            mirrors = apt_config.find_apt_mirror_info(
+                    cfg, arch, os_release=self.os_release)
         mockse.assert_not_called()
 
         self.assertEqual(mirrors['MIRROR'],
@@ -1388,7 +1433,8 @@ deb-src http://ubuntu.com//ubuntu xenial universe multiverse
             )
             write_file.assert_called_with(filepath, expect, mode=0o644)
 
-        default_mirror = apt_config.get_default_mirrors()['PRIMARY']
+        default_mirror = apt_config.get_default_mirrors(
+                os_release=distro.os_release(self.target))['PRIMARY']
 
         # Make sure that default mirrors are replaced correctly when reading
         # from a file.

--- a/tests/unittests/test_apt_source.py
+++ b/tests/unittests/test_apt_source.py
@@ -112,6 +112,10 @@ class TestGetArches(CiTestCase):
              {"amd64", "i386"}),
             ({"ID": "ubuntu", "VERSION_ID": "24.04"},
              {"amd64", "i386"}),
+            ({"ID": "ubuntu", "VERSION_ID": "25.10"},
+             {"amd64", "i386", "arm64"}),
+            ({"ID": "ubuntu", "VERSION_ID": "26.04"},
+             {"amd64", "i386", "arm64"}),
         ),
     )
     def test_primary(self, os_release, expected_arches):
@@ -124,6 +128,10 @@ class TestGetArches(CiTestCase):
              {"s390x", "arm64", "armhf", "powerpc", "ppc64el", "riscv64"}),
             ({"ID": "ubuntu", "VERSION_ID": "24.04"},
              {"s390x", "arm64", "armhf", "powerpc", "ppc64el", "riscv64"}),
+            ({"ID": "ubuntu", "VERSION_ID": "25.10"},
+             {"s390x", "armhf", "powerpc", "ppc64el", "riscv64"}),
+            ({"ID": "ubuntu", "VERSION_ID": "26.04"},
+             {"s390x", "armhf", "powerpc", "ppc64el", "riscv64"}),
         ),
     )
     def test_ports(self, os_release, expected_arches):


### PR DESCRIPTION
When installing 25.10+, we now to configure arm64 to use archive.ubuntu.com instead of ports.ubuntu.com.