### PR TITLE
curthooks: disable early unlock of ZFS keystore

### DIFF
--- a/curtin/commands/curthooks.py
+++ b/curtin/commands/curthooks.py
@@ -2034,8 +2034,9 @@ def curthook_zpool_cache(target: str) -> None:
 
 def curthook_dracut_zvol(target: str, storage_cfg: dict) -> None:
     """
-    add a dracut drop-in file informing it of additional devices to consider,
-    if needed. ensures that cryptsetup is included in the initrd.
+    add a dracut drop-in file, ensuring if needed that cryptsetup is included
+    in the initrd.
+    See LP: #2140415 and LP: #2148282
     """
 
     conf_d = Path(target) / "etc/dracut.conf.d"
@@ -2044,21 +2045,12 @@ def curthook_dracut_zvol(target: str, storage_cfg: dict) -> None:
         return
 
     criteria = dict(type="zpool", encryption_style="luks_keystore")
-    for pool in select_configs(storage_cfg, **criteria):
-        pool_name = pool["pool"]
-        filename = conf_d / f"keystore-{pool_name}.conf"
+    if select_configs(storage_cfg, **criteria):
+        filename = conf_d / "zfs-luks-keystore.conf"
 
-        # LP: #2140415
-        # let dracut know about the keystore zvol, else we fail to decrypt on
-        # first boot. note on dracut syntax - the extra spaces before / after
-        # the device path are not optional!
-        keystore_volume = f"/dev/zvol/{pool_name}/keystore"
-        content = f"""
+        content = """\
 # written by curtin
-# This config ensures that the encrypted pool keystore zvol is inspected by
-# dracut, necessary so that cryptsetup and similar are present in the initrd so
-# that decryption actually takes place.
-add_device+=" {keystore_volume} "
+add_dracutmodules+=" systemd-cryptsetup "
 """
 
         util.write_file(filename, content)

--- a/tests/unittests/test_curthooks.py
+++ b/tests/unittests/test_curthooks.py
@@ -853,12 +853,12 @@ class TestSetupDracut(CiTestCase):
         self.conf_d.mkdir(parents=True)
         curthooks.curthook_dracut_zvol(self.target, self.storage_cfg)
 
-        conf = self.conf_d / f"keystore-{self.pool_name}.conf"
+        conf = self.conf_d / "zfs-luks-keystore.conf"
         for line in conf.read_text().splitlines():
-            if line == f'add_device+=" /dev/zvol/{self.pool_name}/keystore "':
+            if line == 'add_dracutmodules+=" systemd-cryptsetup "':
                 return
 
-        self.fail(f"expected add_device directive in {conf} not found")
+        self.fail(f"expected add_dracutmodules directive in {conf} not found")
 
     def test_create_zvol_no_dropin(self):
         # not a dracut system
@@ -866,7 +866,7 @@ class TestSetupDracut(CiTestCase):
             m_exists.return_value = False
             curthooks.curthook_dracut_zvol(self.target, self.storage_cfg)
 
-        conf = self.conf_d / f"keystore-{self.pool_name}.conf"
+        conf = self.conf_d / "zfs-luks-keystore.conf"
         self.assertFalse(conf.exists())
 
     def test_no_keystore(self):
@@ -875,7 +875,7 @@ class TestSetupDracut(CiTestCase):
             m_exists.return_value = True
             curthooks.curthook_dracut_zvol(self.target, self.storage_cfg)
 
-        conf = self.conf_d / f"keystore-{self.pool_name}.conf"
+        conf = self.conf_d / "zfs-luks-keystore.conf"
         self.assertFalse(conf.exists())
 
 


### PR DESCRIPTION
In host-only mode, the following directive causes dracut to attempt early crypto LUKS detection.
```
add_device=" /dev/zvol/rpool/keystore "
```
by adding `rd.luks.uuid=LUKS=$UUID` to `/etc/cmdline.d/20-crypt.conf`

And this fails because it happens too early.

We already have a way to unlock the ZFS keystore by means of `/var/lib/dracut/hooks/pre-mount/90-zfs-load-key.sh`, so we should use it.

The drop-in file in curtin that contained the `add_device` directive was meant to force dracut to include `systemd-cryptsetup`. Let's use `add_dracutmodules` instead, which does not have the side effect of causing early crypto LUKS detection.

LP:#2148282