### PR TITLE
block: clear_holders modprobe bcache non-fatal (23.1)

### DIFF
--- a/curtin/block/clear_holders.py
+++ b/curtin/block/clear_holders.py
@@ -705,7 +705,10 @@ def start_clear_holders_deps():
     # lad the bcache module bcause it is not present in the kernel. if this
     # happens then there is no need to halt installation, as the bcache devices
     # will never appear and will never prevent the disk from being reformatted
-    util.load_kernel_module('bcache')
+    try:
+        util.load_kernel_module('bcache')
+    except util.ProcessExecutionError:
+        LOG.warning('failed loading bcache module, continuing')
 
     if not zfs.zfs_supported():
         LOG.warning('zfs filesystem is not supported in this environment')

--- a/tests/unittests/test_clear_holders.py
+++ b/tests/unittests/test_clear_holders.py
@@ -767,6 +767,32 @@ class TestClearHolders(CiTestCase):
     @mock.patch('curtin.block.clear_holders.zfs')
     @mock.patch('curtin.block.clear_holders.mdadm')
     @mock.patch('curtin.block.clear_holders.util')
+    def test_clear_holders_failed_bcache(self, mock_util, mock_mdadm, mock_zfs,
+                                         mock_lvm, mock_mp, mock_udev):
+
+        err = (
+            "modprobe: FATAL: Module bcache not found in directory "
+            "/lib/modules/7.0.0-13-generic"
+        )
+        cmd = ['modprobe', '--use-blacklist', 'bcache']
+        mock_util.load_kernel_module.side_effect = [
+            ProcessExecutionError(cmd=cmd, stdout='', stderr=err, exit_code=1)
+        ]
+
+        # during test time, because all of util is mocked,
+        # ProcessExecutionError is mocked also, so fix that.
+        mock_util.ProcessExecutionError = ProcessExecutionError
+        mock_zfs.zfs_supported.return_value = True
+        clear_holders.start_clear_holders_deps()
+        mock_util.load_kernel_module.assert_has_calls([mock.call('bcache')])
+        self.assertEqual(1, mock_zfs.zfs_supported.call_count)
+
+    @mock.patch('curtin.block.clear_holders.udev')
+    @mock.patch('curtin.block.clear_holders.multipath')
+    @mock.patch('curtin.block.clear_holders.lvm')
+    @mock.patch('curtin.block.clear_holders.zfs')
+    @mock.patch('curtin.block.clear_holders.mdadm')
+    @mock.patch('curtin.block.clear_holders.util')
     def test_start_clear_holders_deps_nozfs(self, mock_util, mock_mdadm,
                                             mock_zfs, mock_lvm, mock_mp,
                                             mock_udev):


### PR DESCRIPTION
LP:#2147471 notes that bcache.ko may not be present.  The comment above this modprobe even notes that this should not be fatal.  Just warn if the module can't be loaded.


(cherry picked from commit 5ece4571effee0417dbc3d2289e134bf9757ccca)