### PR TITLE
curthooks: remove ZFS drop-in file not needed anymore

### DIFF
--- a/curtin/commands/curthooks.py
+++ b/curtin/commands/curthooks.py
@@ -10,7 +10,6 @@ import re
 import sys
 import shutil
 import textwrap
-from pathlib import Path
 from typing import List, Tuple
 
 from curtin import config
@@ -2032,30 +2031,6 @@ def curthook_zpool_cache(target: str) -> None:
         copy_zpool_cache(zpool_cache, target)
 
 
-def curthook_dracut_zvol(target: str, storage_cfg: dict) -> None:
-    """
-    add a dracut drop-in file, ensuring if needed that cryptsetup is included
-    in the initrd.
-    See LP: #2140415 and LP: #2148282
-    """
-
-    conf_d = Path(target) / "etc/dracut.conf.d"
-    if not conf_d.exists():
-        # not a dracut system seemingly
-        return
-
-    criteria = dict(type="zpool", encryption_style="luks_keystore")
-    if select_configs(storage_cfg, **criteria):
-        filename = conf_d / "zfs-luks-keystore.conf"
-
-        content = """\
-# written by curtin
-add_dracutmodules+=" systemd-cryptsetup "
-"""
-
-        util.write_file(filename, content)
-
-
 def curthook_zkey(target: str, osfamily, state) -> None:
     zkey_repository = '/etc/zkey/repository'
     zkey_used = os.path.join(os.path.split(state['fstab'])[0], "zkey_used")
@@ -2195,7 +2170,6 @@ def builtin_curthooks(cfg: dict, target: str, state: dict):
 
     if osfamily == DISTROS.debian:
         curthook_zpool_cache(target)
-        curthook_dracut_zvol(target, extract_storage_ordered_dict(cfg))
         curthook_zkey(target, osfamily, state)
         curthook_crypttab(target, state)
 

--- a/tests/unittests/test_curthooks.py
+++ b/tests/unittests/test_curthooks.py
@@ -831,54 +831,6 @@ class TestInstallMissingPkgs(CiTestCase):
         self.assertEqual(expected_pkgs, sorted(mock_call.args[0]))
 
 
-class TestSetupDracut(CiTestCase):
-    def setUp(self):
-        self.target = self.tmp_dir()
-        self.conf_d = Path(self.target) / "etc/dracut.conf.d"
-        self.pool_name = self.random_string()
-        self.cfg = {
-            'storage': {
-                'version': 1,
-                'config': [{
-                    'id': 'test_pool',
-                    'encryption_style': 'luks_keystore',
-                    'type': 'zpool',
-                    'pool': self.pool_name,
-                }]
-            },
-        }
-        self.storage_cfg = extract_storage_ordered_dict(self.cfg)
-
-    def test_create_zvol_dropin(self):
-        self.conf_d.mkdir(parents=True)
-        curthooks.curthook_dracut_zvol(self.target, self.storage_cfg)
-
-        conf = self.conf_d / "zfs-luks-keystore.conf"
-        for line in conf.read_text().splitlines():
-            if line == 'add_dracutmodules+=" systemd-cryptsetup "':
-                return
-
-        self.fail(f"expected add_dracutmodules directive in {conf} not found")
-
-    def test_create_zvol_no_dropin(self):
-        # not a dracut system
-        with patch('curtin.commands.curthooks.Path.exists') as m_exists:
-            m_exists.return_value = False
-            curthooks.curthook_dracut_zvol(self.target, self.storage_cfg)
-
-        conf = self.conf_d / "zfs-luks-keystore.conf"
-        self.assertFalse(conf.exists())
-
-    def test_no_keystore(self):
-        self.cfg["storage"]["config"][0]["encryption_style"] = None
-        with patch('curtin.commands.curthooks.Path.exists') as m_exists:
-            m_exists.return_value = True
-            curthooks.curthook_dracut_zvol(self.target, self.storage_cfg)
-
-        conf = self.conf_d / "zfs-luks-keystore.conf"
-        self.assertFalse(conf.exists())
-
-
 class TestSetupZipl(CiTestCase):
 
     def setUp(self):


### PR DESCRIPTION
During Ubuntu 26.04 development, when necessary, we relied on a drop-in file placed under /etc/dracut.conf.d/ to tell dracut it needs to include encryption support for ZFS.

But the version of zfs-linux that ended up in the resolute release pocket (i.e., 2.4.1-1ubuntu5) has improved detection and makes this drop-in file unnecessary.

We can now get rid of it.