### PR TITLE
curtin: replace use of logging.warn by logging.warning

### DIFF
--- a/curtin/block/__init__.py
+++ b/curtin/block/__init__.py
@@ -498,7 +498,7 @@ def stop_all_unused_multipath_devices():
         # unless multipath cleared *everything* it will exit with 1
         util.subp(cmd, rcs=[0, 1])
     except util.ProcessExecutionError as e:
-        LOG.warn("Failed to stop multipath devices: %s", e)
+        LOG.warning("Failed to stop multipath devices: %s", e)
 
 
 def rescan_block_devices(devices=None, warn_on_fail=True):
@@ -529,12 +529,12 @@ def rescan_block_devices(devices=None, warn_on_fail=True):
         if warn_on_fail:
             # FIXME: its less than ideal to swallow this error, but until
             # we fix LP: #1489521 we kind of need to.
-            LOG.warn(
+            LOG.warning(
                 "Error rescanning devices, possibly known issue LP: #1489521")
             # Reformatting the exception output so as to not trigger
             # vmtest scanning for Unexepected errors in install logfile
-            LOG.warn("cmd: %s\nstdout:%s\nstderr:%s\nexit_code:%s", e.cmd,
-                     e.stdout, e.stderr, e.exit_code)
+            LOG.warning("cmd: %s\nstdout:%s\nstderr:%s\nexit_code:%s", e.cmd,
+                        e.stdout, e.stderr, e.exit_code)
 
     udevadm_settle()
 
@@ -647,7 +647,7 @@ def get_scsi_wwid(device, replace_whitespace=False):
         scsi_wwid = out.rstrip('\n')
         return scsi_wwid
     except util.ProcessExecutionError as e:
-        LOG.warn("Failed to get WWID: %s", e)
+        LOG.warning("Failed to get WWID: %s", e)
         return None
 
 

--- a/curtin/block/iscsi.py
+++ b/curtin/block/iscsi.py
@@ -218,8 +218,8 @@ def ensure_disk_connected(rfc4173, write_config=True):
     # this is just a sanity check that the disk is actually present and
     # the above did what we expected
     if not os.path.exists(iscsi_disk.devdisk_path):
-        LOG.warn('Unable to find iSCSI disk for target (%s) by path (%s)',
-                 iscsi_disk.target, iscsi_disk.devdisk_path)
+        LOG.warning('Unable to find iSCSI disk for target (%s) by path (%s)',
+                    iscsi_disk.target, iscsi_disk.devdisk_path)
 
     return iscsi_disk
 
@@ -282,8 +282,8 @@ def disconnect_target_disks(target_root_path=None):
                     iscsiadm_logout(target, '%s:%s' % (host, port))
                 except util.ProcessExecutionError as e:
                     fails.append(target)
-                    LOG.warn("Unable to logout of iSCSI target %s: %s",
-                             target, e)
+                    LOG.warning("Unable to logout of iSCSI target %s: %s",
+                                target, e)
     else:
         LOG.warning('Skipping disconnect: failed to find iscsi nodes path: %s',
                     target_nodes_path)
@@ -368,8 +368,8 @@ class IscsiDisk(object):
                              'host:proto:port:lun:targetname' % _rfc4173)
 
         if target_m.group('proto') and target_m.group('proto') != '6':
-            LOG.warn('Specified protocol for iSCSI (%s) is unsupported, '
-                     'assuming 6 (TCP)', target_m.group('proto'))
+            LOG.warning('Specified protocol for iSCSI (%s) is unsupported, '
+                        'assuming 6 (TCP)', target_m.group('proto'))
 
         if not target_m.group('host') or not target_m.group('targetname'):
             raise ValueError('Both host and targetname must be specified for '
@@ -453,7 +453,8 @@ class IscsiDisk(object):
             util.subp(['sync'])
             iscsiadm_logout(self.target, self.portal)
         except util.ProcessExecutionError as e:
-            LOG.warn("Unable to logout of iSCSI target %s from portal %s: %s",
-                     self.target, self.portal, e)
+            LOG.warning(
+                "Unable to logout of iSCSI target %s from portal %s: %s",
+                self.target, self.portal, e)
 
 # vi: ts=4 expandtab syntax=python

--- a/curtin/commands/apply_net.py
+++ b/curtin/commands/apply_net.py
@@ -142,7 +142,7 @@ def _disable_ipv6_privacy_extensions(target,
     LOG.debug('Attempting to remove ipv6 privacy extensions')
     cfg = paths.target_path(target, path=path)
     if not os.path.exists(cfg):
-        LOG.warn('Failed to find ipv6 privacy conf file %s', cfg)
+        LOG.warning('Failed to find ipv6 privacy conf file %s', cfg)
         return
 
     bmsg = "Disabling IPv6 privacy extensions config may not apply."
@@ -188,7 +188,7 @@ def _maybe_remove_legacy_eth0(target,
 
     cfg = paths.target_path(target, path=path)
     if not os.path.exists(cfg):
-        LOG.warn('Failed to find legacy network conf file %s', cfg)
+        LOG.warning('Failed to find legacy network conf file %s', cfg)
         return
 
     bmsg = "Dynamic networking config may not apply."
@@ -207,7 +207,7 @@ def _maybe_remove_legacy_eth0(target,
         LOG.exception(msg)
         raise
 
-    LOG.warn(msg)
+    LOG.warning(msg)
 
 
 def apply_net_main(args):

--- a/curtin/commands/apt_config.py
+++ b/curtin/commands/apt_config.py
@@ -364,8 +364,8 @@ def dpkg_reconfigure(packages, target=None):
             unhandled.append(pkg)
 
     if len(unhandled):
-        LOG.warn("The following packages were installed and preseeded, "
-                 "but cannot be unconfigured: %s", unhandled)
+        LOG.warning("The following packages were installed and preseeded, "
+                    "but cannot be unconfigured: %s", unhandled)
 
     if len(to_config):
         util.subp(['dpkg-reconfigure', '--frontend=noninteractive'] +
@@ -459,7 +459,7 @@ def rename_apt_lists(new_mirrors, target=None, arch=None):
                 os.rename(filename, newname)
             except OSError:
                 # since this is a best effort task, warn with but don't fail
-                LOG.warn("Failed to rename apt list:", exc_info=True)
+                LOG.warning("Failed to rename apt list:", exc_info=True)
 
 
 def make_mirrors_replacement(mirrors, target, arch=None):

--- a/curtin/commands/block_meta.py
+++ b/curtin/commands/block_meta.py
@@ -253,8 +253,8 @@ def determine_partition_number(partition_id, storage_config):
     partnumber = vol.get('number')
     if vol.get('flag') == "logical":
         if not partnumber:
-            LOG.warn('partition \'number\' key not set in config:\n%s',
-                     util.json_dumps(vol))
+            LOG.warning('partition \'number\' key not set in config:\n%s',
+                        util.json_dumps(vol))
             partnumber = 5
             for key, item in storage_config.items():
                 if item.get('type') == "partition" and \
@@ -266,8 +266,8 @@ def determine_partition_number(partition_id, storage_config):
                         partnumber += 1
     else:
         if not partnumber:
-            LOG.warn('partition \'number\' key not set in config:\n%s',
-                     util.json_dumps(vol))
+            LOG.warning('partition \'number\' key not set in config:\n%s',
+                        util.json_dumps(vol))
             partnumber = 1
             for key, item in storage_config.items():
                 if item.get('type') == "partition" and \
@@ -1127,8 +1127,8 @@ def partition_handler(info, storage_config, context):
         if config.value_as_boolean(info.get('wipe')):
             LOG.info("Preparing partition location on disk %s", disk)
             if info.get('flag') == "extended":
-                LOG.warn("extended partitions do not need wiping, "
-                         "so skipping: '%s'" % info.get('id'))
+                LOG.warning("extended partitions do not need wiping, "
+                            "so skipping: '%s'" % info.get('id'))
             else:
                 # wipe the start of the new partition first by zeroing 1M at
                 # the length of the previous partition
@@ -2360,8 +2360,8 @@ def meta_simple(args):
 
     if len(devices) == 0 and devpath is None:
         devices = block.get_installable_blockdevs()
-        LOG.warn("'%s' mode, no devices given. unused list: %s",
-                 args.mode, devices)
+        LOG.warning("'%s' mode, no devices given. unused list: %s",
+                    args.mode, devices)
         # Check if the list of installable block devices is still empty after
         # checking for block devices and filtering out the removable ones.  In
         # this case we may have a system which has its harddrives reported by
@@ -2375,21 +2375,22 @@ def meta_simple(args):
                 raise Exception("No valid target devices found that curtin "
                                 "can install on.")
             else:
-                LOG.warn("No non-removable, installable devices found. List "
-                         "populated with removable devices allowed: %s",
-                         devices)
+                LOG.warning(
+                    "No non-removable, installable devices found. List "
+                    "populated with removable devices allowed: %s",
+                    devices)
 
     if devpath is not None:
         target = devpath
     elif len(devices) > 1:
         if args.devices is not None:
-            LOG.warn("'%s' mode but multiple devices given. "
-                     "using first found", args.mode)
+            LOG.warning("'%s' mode but multiple devices given. "
+                        "using first found", args.mode)
         available = [f for f in devices
                      if block.is_valid_device(f)]
         target = sorted(available)[0]
-        LOG.warn("mode is '%s'. multiple devices given. using '%s' "
-                 "(first available)", args.mode, target)
+        LOG.warning("mode is '%s'. multiple devices given. using '%s' "
+                    "(first available)", args.mode, target)
     else:
         target = devices[0]
 
@@ -2440,8 +2441,8 @@ def meta_simple(args):
         if os.path.exists("%sp%s" % (devnode, rootdev_ptnum)):
             ptpre = "p"
         else:
-            LOG.warn("root device %s%s did not exist, expecting failure",
-                     devnode, rootdev_ptnum)
+            LOG.warning("root device %s%s did not exist, expecting failure",
+                        devnode, rootdev_ptnum)
 
     if bootdev_ptnum:
         bootdev = "%s%s%s" % (devnode, ptpre, bootdev_ptnum)

--- a/curtin/commands/curthooks.py
+++ b/curtin/commands/curthooks.py
@@ -189,7 +189,7 @@ def setup_zipl(cfg, target):
 
     if not root_arg:
         msg = "Failed to identify root= for %s at %s." % (target, target_dev)
-        LOG.warn(msg)
+        LOG.warning(msg)
         raise ValueError(msg)
 
     zipl_conf = """
@@ -430,8 +430,9 @@ def install_kernel(cfg, target):
                          package, kernel_cfg.fallback_package)
                 install(kernel_cfg.fallback_package)
             else:
-                LOG.warn("Kernel package '%s' not available and no fallback."
-                         " System may not boot.", package)
+                LOG.warning(
+                    "Kernel package '%s' not available and no fallback."
+                    " System may not boot.", package)
 
 
 def uefi_remove_old_loaders(bootcfg: config.BootCfg, target: str):
@@ -708,7 +709,7 @@ def uefi_find_grub_device_ids(sconfig):
             if sconfig[primary_esp]['type'] == 'partition':
                 LOG.debug("Found primary UEFI ESP: %s", primary_esp)
             else:
-                LOG.warn('Found primary ESP not on a partition: %s', item)
+                LOG.warning('Found primary ESP not on a partition: %s', item)
 
     if primary_esp is None:
         raise RuntimeError('Failed to find primary ESP mounted at /boot/efi')
@@ -774,9 +775,10 @@ def setup_grub(
         if len(storage_grub_devices) > 0:
             if bootcfg.install_devices and \
                bootcfg.install_devices is not bootcfg.install_devices_default:
-                LOG.warn("Storage Config grub device config takes precedence "
-                         "over grub 'install_devices' value, ignoring: %s",
-                         bootcfg['install_devices'])
+                LOG.warning(
+                    "Storage Config grub device config takes precedence "
+                    "over grub 'install_devices' value, ignoring: %s",
+                    bootcfg['install_devices'])
             bootcfg.install_devices = storage_grub_devices
 
     LOG.debug("install_devices: %s", bootcfg.install_devices)
@@ -816,10 +818,10 @@ def setup_grub(
                     capture=True)
                 instdevs = str(out).splitlines()
                 if not instdevs:
-                    LOG.warn("No power grub target partitions found!")
+                    LOG.warning("No power grub target partitions found!")
                     instdevs = None
             except util.ProcessExecutionError as e:
-                LOG.warn("Failed to find power grub partitions: %s", e)
+                LOG.warning("Failed to find power grub partitions: %s", e)
                 instdevs = None
         else:
             instdevs = list(blockdevs)
@@ -1013,7 +1015,7 @@ def update_initramfs(target=None, all_kernels=False):
 
 def copy_fstab(fstab, target):
     if not fstab:
-        LOG.warn("fstab variable not in state, not copying fstab")
+        LOG.warning("fstab variable not in state, not copying fstab")
         return
 
     content = util.load_file(fstab)
@@ -1024,7 +1026,7 @@ def copy_fstab(fstab, target):
 
 def copy_crypttab(crypttab, target):
     if not crypttab:
-        LOG.warn("crypttab config must be specified, not copying")
+        LOG.warning("crypttab config must be specified, not copying")
         return
 
     shutil.copy(crypttab, os.path.sep.join([target, 'etc/crypttab']))
@@ -1058,7 +1060,7 @@ def copy_cdrom(cdrom: str, target: str) -> None:
 
 def copy_iscsi_conf(nodes_dir, target, target_nodes_dir='etc/iscsi/nodes'):
     if not nodes_dir:
-        LOG.warn("nodes directory must be specified, not copying")
+        LOG.warning("nodes directory must be specified, not copying")
         return
 
     LOG.info("copying iscsi nodes database into target")
@@ -1075,7 +1077,7 @@ def copy_iscsi_conf(nodes_dir, target, target_nodes_dir='etc/iscsi/nodes'):
 
 def copy_mdadm_conf(mdadm_conf, target):
     if not mdadm_conf:
-        LOG.warn("mdadm config must be specified, not copying")
+        LOG.warning("mdadm config must be specified, not copying")
         return
 
     LOG.info("copying mdadm.conf into target")
@@ -1085,7 +1087,7 @@ def copy_mdadm_conf(mdadm_conf, target):
 
 def copy_zpool_cache(zpool_cache, target):
     if not zpool_cache:
-        LOG.warn("zpool_cache path must be specified, not copying")
+        LOG.warning("zpool_cache path must be specified, not copying")
         return
 
     shutil.copy(zpool_cache, os.path.sep.join([target, 'etc/zfs']))
@@ -1094,7 +1096,7 @@ def copy_zpool_cache(zpool_cache, target):
 def copy_zkey_repository(zkey_repository, target,
                          target_repo='etc/zkey/repository'):
     if not zkey_repository:
-        LOG.warn("zkey repository path must be specified, not copying")
+        LOG.warning("zkey repository path must be specified, not copying")
         return
 
     tdir = os.path.sep.join([target, target_repo])
@@ -1133,7 +1135,7 @@ def apply_networking(target, state):
 
 def copy_interfaces(interfaces, target):
     if not interfaces or not os.path.exists(interfaces):
-        LOG.warn("no interfaces file to copy!")
+        LOG.warning("no interfaces file to copy!")
         return
     eni = os.path.sep.join([target, 'etc/network/interfaces'])
     shutil.copy(interfaces, eni)
@@ -1141,7 +1143,7 @@ def copy_interfaces(interfaces, target):
 
 def copy_dname_rules(rules_d, target):
     if not rules_d:
-        LOG.warn("no udev rules directory to copy")
+        LOG.warning("no udev rules directory to copy")
         return
     target_rules_dir = paths.target_path(target, "etc/udev/rules.d")
     for rule in os.listdir(rules_d):
@@ -1238,8 +1240,8 @@ def detect_and_handle_multipath(cfg, target, osfamily=DISTROS.debian):
             if pkg_ver['semantic_version'] < 500:
                 replace_spaces = False
         except Exception as e:
-            LOG.warn("failed reading multipath-tools version, "
-                     "assuming it wants no spaces in wwids: %s", e)
+            LOG.warning("failed reading multipath-tools version, "
+                        "assuming it wants no spaces in wwids: %s", e)
 
     multipath_cfg_path = os.path.sep.join([target, '/etc/multipath.conf'])
     multipath_bind_path = os.path.sep.join([target, '/etc/multipath/bindings'])
@@ -1350,7 +1352,7 @@ def detect_and_handle_multipath(cfg, target, osfamily=DISTROS.debian):
             util.write_file(grub_cfg, omode=omode, content=msg)
 
     else:
-        LOG.warn("Not sure how this will boot")
+        LOG.warning("Not sure how this will boot")
 
     if osfamily == DISTROS.debian:
         # Initrams needs to be updated to include /etc/multipath.cfg

--- a/curtin/commands/install.py
+++ b/curtin/commands/install.py
@@ -76,10 +76,10 @@ def copy_install_log(logfile, target, log_target_path):
     """Copy curtin install log file to target system"""
     basemsg = 'Cannot copy curtin install log "%s" to target.' % logfile
     if not logfile:
-        LOG.warn(basemsg)
+        LOG.warning(basemsg)
         return
     if not os.path.isfile(logfile):
-        LOG.warn(basemsg + "  file does not exist.")
+        LOG.warning(basemsg + "  file does not exist.")
         return
 
     LOG.debug('Copying curtin install log from %s to target/%s',
@@ -278,7 +278,7 @@ class Stage(object):
                             stderr=subprocess.STDOUT,
                             env=env, shell=shell)
                     except OSError as e:
-                        LOG.warn("%s command failed", cmdname)
+                        LOG.warning("%s command failed", cmdname)
                         raise util.ProcessExecutionError(cmd=cmd, reason=e)
 
                     output = b""
@@ -291,7 +291,7 @@ class Stage(object):
 
                     rc = sp.returncode
                     if rc != 0:
-                        LOG.warn("%s command failed", cmdname)
+                        LOG.warning("%s command failed", cmdname)
                         raise util.ProcessExecutionError(
                             stdout=output, stderr="",
                             exit_code=rc, cmd=cmd)
@@ -315,7 +315,7 @@ def apply_power_state(pstate):
             util.subp(cmd)
             os._exit(0)
         except Exception as e:
-            LOG.warn("%s returned non-zero: %s" % (cmd, e))
+            LOG.warning("%s returned non-zero: %s" % (cmd, e))
             os._exit(1)
     return
 
@@ -430,9 +430,9 @@ def migrate_proxy_settings(cfg):
         hp = cfg['http_proxy']
         if hp:
             if proxy.get('http_proxy', hp) != hp:
-                LOG.warn("legacy http_proxy setting (%s) differs from "
-                         "proxy/http_proxy (%s), using %s",
-                         hp, proxy['http_proxy'], proxy['http_proxy'])
+                LOG.warning("legacy http_proxy setting (%s) differs from "
+                            "proxy/http_proxy (%s), using %s",
+                            hp, proxy['http_proxy'], proxy['http_proxy'])
             else:
                 LOG.debug("legacy 'http_proxy' migrated to proxy/http_proxy")
                 proxy['http_proxy'] = hp

--- a/curtin/commands/net_meta.py
+++ b/curtin/commands/net_meta.py
@@ -120,8 +120,8 @@ def net_meta(args):
         t_eni = os.path.sep.join((args.target, "etc/network/interfaces",))
         with open(t_eni, "r") as fp:
             content = fp.read()
-        LOG.warn("net-meta mode is 'copy', static network interfaces files"
-                 "can be brittle.  Copied interfaces: %s", content)
+        LOG.warning("net-meta mode is 'copy', static network interfaces files"
+                    "can be brittle.  Copied interfaces: %s", content)
         target = args.output
 
     elif args.mode == "dhcp":

--- a/curtin/commands/system_install.py
+++ b/curtin/commands/system_install.py
@@ -24,7 +24,7 @@ def system_install_pkgs_main(args):
             download_only=args.download_only,
             assume_downloaded=args.assume_downloaded)
     except util.ProcessExecutionError as e:
-        LOG.warn("system install failed for %s: %s" % (args.packages, e))
+        LOG.warning("system install failed for %s: %s" % (args.packages, e))
         exit_code = e.exit_code
 
     sys.exit(exit_code)

--- a/curtin/commands/system_upgrade.py
+++ b/curtin/commands/system_upgrade.py
@@ -21,7 +21,7 @@ def system_upgrade_main(args):
                               allow_daemons=args.allow_daemons,
                               download_retries=args.download_retry_after)
     except util.ProcessExecutionError as e:
-        LOG.warn("system upgrade failed: %s" % e)
+        LOG.warning("system upgrade failed: %s" % e)
         exit_code = e.exit_code
 
     sys.exit(exit_code)

--- a/curtin/distro.py
+++ b/curtin/distro.py
@@ -184,11 +184,11 @@ def _lsb_release(target=None):
                 data[fmap[fname]] = val.strip()
         missing = [k for k in fmap.values() if k not in data]
         if len(missing):
-            LOG.warn("Missing fields in lsb_release --all output: %s",
-                     ','.join(missing))
+            LOG.warning("Missing fields in lsb_release --all output: %s",
+                        ','.join(missing))
 
     except ProcessExecutionError as err:
-        LOG.warn("Unable to get lsb_release --all: %s", err)
+        LOG.warning("Unable to get lsb_release --all: %s", err)
         data = {v: "UNAVAILABLE" for v in fmap.values()}
 
     return data

--- a/curtin/futil.py
+++ b/curtin/futil.py
@@ -81,7 +81,7 @@ def write_files(files, base_dir=None):
        owner: (optional, default -1:-1): string of 'uid:gid'."""
     for (key, info) in files.items():
         if not info.get('path'):
-            LOG.warn("Warning, write_files[%s] had no 'path' entry", key)
+            LOG.warning("Warning, write_files[%s] had no 'path' entry", key)
             continue
 
         write_finfo(path=target_path(base_dir, info['path']),

--- a/curtin/gpg.py
+++ b/curtin/gpg.py
@@ -39,7 +39,7 @@ def delete_key(key):
         util.subp(["gpg", "--batch", "--yes", "--delete-keys", key],
                   capture=True)
     except util.ProcessExecutionError as error:
-        LOG.warn('Failed delete key "%s": %s', key, error)
+        LOG.warning('Failed delete key "%s": %s', key, error)
 
 
 def getkeybyid(keyid, keyserver='keyserver.ubuntu.com', retries=None):

--- a/curtin/net/network_state.py
+++ b/curtin/net/network_state.py
@@ -100,7 +100,7 @@ class NetworkState:
             'name',
         ]
         if not self.valid_command(command, required_keys):
-            LOG.warn('Skipping Invalid command: %s', command)
+            LOG.warning('Skipping Invalid command: %s', command)
             LOG.debug(self.dump_network_state())
             return
 
@@ -266,8 +266,8 @@ class NetworkState:
             'params',
         ]
         if not self.valid_command(command, required_keys):
-            LOG.warn('Skipping Invalid command: %s', command)
-            LOG.warn(self.dump_network_state())
+            LOG.warning('Skipping Invalid command: %s', command)
+            LOG.warning(self.dump_network_state())
             return
 
         # find one of the bridge port ifaces to get mac_addr
@@ -297,8 +297,8 @@ class NetworkState:
             'address',
         ]
         if not self.valid_command(command, required_keys):
-            LOG.warn('Skipping Invalid command: %s', command)
-            LOG.warn(self.dump_network_state())
+            LOG.warning('Skipping Invalid command: %s', command)
+            LOG.warning(self.dump_network_state())
             return
 
         dns = self.network_state.get('dns')
@@ -320,8 +320,8 @@ class NetworkState:
             'destination',
         ]
         if not self.valid_command(command, required_keys):
-            LOG.warn('Skipping Invalid command: %s', command)
-            LOG.warn(self.dump_network_state())
+            LOG.warning('Skipping Invalid command: %s', command)
+            LOG.warning(self.dump_network_state())
             return
 
         routes = self.network_state.get('routes')

--- a/curtin/reporter/handlers.py
+++ b/curtin/reporter/handlers.py
@@ -34,7 +34,7 @@ class LogHandler(ReportingHandler):
             try:
                 level = getattr(logging, level.upper())
             except Exception:
-                LOG.warn("invalid level '%s', using WARN", input_level)
+                LOG.warning("invalid level '%s', using WARN", input_level)
                 level = logging.WARN
         self.level = level
 
@@ -67,7 +67,7 @@ class WebHookHandler(ReportingHandler):
         try:
             self.level = getattr(logging, level.upper())
         except Exception:
-            LOG.warn("invalid level '%s', using WARN", level)
+            LOG.warning("invalid level '%s', using WARN", level)
             self.level = logging.WARN
         self.headers = {'Content-Type': 'application/json'}
 
@@ -77,7 +77,8 @@ class WebHookHandler(ReportingHandler):
                 url=self.endpoint, data=event.as_dict(),
                 headers=self.headers, retries=self.retries)
         except Exception as e:
-            LOG.warn("failed posting event: %s [%s]" % (event.as_string(), e))
+            LOG.warning("failed posting event: %s [%s]" %
+                        (event.as_string(), e))
 
 
 class JournaldHandler(ReportingHandler):
@@ -91,7 +92,7 @@ class JournaldHandler(ReportingHandler):
             try:
                 level = getattr(logging, level.upper())
             except Exception:
-                LOG.warn("invalid level '%s', using WARN", input_level)
+                LOG.warning("invalid level '%s', using WARN", input_level)
                 level = logging.WARN
         self.level = level
         self.identifier = identifier

--- a/curtin/storage_config.py
+++ b/curtin/storage_config.py
@@ -1249,7 +1249,7 @@ class MountParser(ProbertParser):
         # TODO: ideally, we should not rely on the value of the DM_NAME
         # attribute. Other image loading systems will have a different value.
         if self.blockdev_data[source].get("DM_NAME") == "ventoy":
-            LOG.warn("ignoring mount for device %s", source)
+            LOG.warning("ignoring mount for device %s", source)
             return {}
 
         source_id = self.blockdev_to_id(self.blockdev_data[source])

--- a/curtin/swap.py
+++ b/curtin/swap.py
@@ -123,7 +123,7 @@ def get_target_kernel_version(target):
             pkg_ver = distro.get_package_version('linux-image-generic',
                                                  target=target)
         except Exception as e:
-            LOG.warn(
+            LOG.warning(
                 "failed reading linux-image-generic package version, %s", e)
     return pkg_ver
 
@@ -192,7 +192,7 @@ def setup_swapfile(target, fstab=None, swapfile=None, size=None, maxsize=None,
                  (' && mkswap "$1" || { r=$?; rm -f "$1"; exit $r; }'),
                  'setup_swap', fpath, mbsize])
     except Exception:
-        LOG.warn("failed %s" % msg)
+        LOG.warning("failed %s" % msg)
         raise
 
     if fstab is None:

--- a/curtin/url_helper.py
+++ b/curtin/url_helper.py
@@ -157,7 +157,7 @@ def get_maas_version(endpoint):
     try:
         parsed = urlparse(endpoint)
     except AttributeError as e:
-        LOG.warn('Failed to parse endpoint URL: %s', e)
+        LOG.warning('Failed to parse endpoint URL: %s', e)
         return None
 
     maas_host = "%s://%s" % (parsed.scheme, parsed.netloc)
@@ -166,14 +166,14 @@ def get_maas_version(endpoint):
     try:
         result = geturl(maas_api_version_url)
     except UrlError as e:
-        LOG.warn('Failed to query MAAS API version URL: %s', e)
+        LOG.warning('Failed to query MAAS API version URL: %s', e)
         return None
 
     api_version = result.decode('utf-8')
     if api_version not in MAAS_API_SUPPORTED_VERSIONS:
-        LOG.warn('Endpoint "%s" API version "%s" not in MAAS supported'
-                 'versions: "%s"', endpoint, api_version,
-                 MAAS_API_SUPPORTED_VERSIONS)
+        LOG.warning('Endpoint "%s" API version "%s" not in MAAS supported'
+                    'versions: "%s"', endpoint, api_version,
+                    MAAS_API_SUPPORTED_VERSIONS)
         return None
 
     maas_version_url = "%s/MAAS/api/%s/version/" % (maas_host, api_version)
@@ -182,9 +182,9 @@ def get_maas_version(endpoint):
         result = geturl(maas_version_url)
         maas_version = json.loads(result.decode('utf-8'))
     except UrlError as e:
-        LOG.warn('Failed to query MAAS version via URL: %s', e)
+        LOG.warning('Failed to query MAAS version via URL: %s', e)
     except (ValueError, TypeError):
-        LOG.warn('Failed to load MAAS version result: %s', result)
+        LOG.warning('Failed to load MAAS version result: %s', result)
 
     return maas_version
 
@@ -342,14 +342,14 @@ class OauthUrlHelper(object):
             return
 
         if 'date' not in exception.headers:
-            LOG.warn("Missing header 'date' in %s response", exception.code)
+            LOG.warning("Missing header 'date' in %s response", exception.code)
             return
 
         date = exception.headers['date']
         try:
             remote_time = time.mktime(parsedate(date))
         except Exception as e:
-            LOG.warn("Failed to convert datetime '%s': %s", date, e)
+            LOG.warning("Failed to convert datetime '%s': %s", date, e)
             return
 
         skew = int(remote_time - time.time())
@@ -357,7 +357,7 @@ class OauthUrlHelper(object):
         old_skew = self.skew_data.get(host, 0)
         if abs(old_skew - skew) > self.skew_change_limit:
             self.update_skew_file(host, skew)
-            LOG.warn("Setting oauth clockskew for %s to %d", host, skew)
+            LOG.warning("Setting oauth clockskew for %s to %d", host, skew)
         self.skew_data[host] = skew
 
         return

--- a/tests/unittests/test_url_helper.py
+++ b/tests/unittests/test_url_helper.py
@@ -112,8 +112,8 @@ class TestGetMaasVersion(CiTestCase):
         ])
         result = url_helper.get_maas_version(endpoint)
         self.assertIsNone(result)
-        self.assertTrue(mock_log.warn.called)
-        mock_log.warn.assert_called_with(
+        self.assertTrue(mock_log.warning.called)
+        mock_log.warning.assert_called_with(
             'Endpoint "%s" API version "%s" not in MAAS supported'
             'versions: "%s"', endpoint, maas_api_version, supported)
         mock_get_url.assert_has_calls([
@@ -140,8 +140,8 @@ class TestGetMaasVersion(CiTestCase):
         ])
         result = url_helper.get_maas_version(endpoint)
         self.assertIsNone(result)
-        self.assertTrue(mock_log.warn.called)
-        mock_log.warn.assert_called_with(
+        self.assertTrue(mock_log.warning.called)
+        mock_log.warning.assert_called_with(
             'Failed to load MAAS version result: %s', bad_json)
         mock_get_url.assert_has_calls([
             mock.call('http://%s/MAAS/api/version/' % host),
@@ -164,8 +164,8 @@ class TestGetMaasVersion(CiTestCase):
         ])
         result = url_helper.get_maas_version(endpoint)
         self.assertIsNone(result)
-        self.assertTrue(mock_log.warn.called)
-        mock_log.warn.assert_called_with(
+        self.assertTrue(mock_log.warning.called)
+        mock_log.warning.assert_called_with(
             'Failed to query MAAS version via URL: %s', exception)
         mock_get_url.assert_has_calls([
             mock.call('http://%s/MAAS/api/version/' % host),


### PR DESCRIPTION
`logging.warn` has been deprecated in favor of `logging.warning`.

`logging.warn` was planned to be dropped from Python 3.13 but was eventually restored.
    
Let's replace all occurrences of `logging.warn` to be compatible with future Python
