### PR TITLE
block: fix missing tuple in ValueError format string

### DIFF
--- a/curtin/block/mkfs.py
+++ b/curtin/block/mkfs.py
@@ -123,7 +123,7 @@ def get_flag_mapping(flag_name, fs_family, param=None, strict=False):
     if flag_sym is None:
         if strict:
             raise ValueError("flag '%s' not supported by fs family '%s'" %
-                             flag_name, fs_family)
+                             (flag_name, fs_family))
         else:
             return ret
 

--- a/tests/unittests/test_block_mkfs.py
+++ b/tests/unittests/test_block_mkfs.py
@@ -180,4 +180,13 @@ class TestBlockMkfs(CiTestCase):
         uuid = mkfs.mkfs("/dev/null", "ext4")
         self.assertIsNotNone(uuid)
 
+
+class TestGetFlagMapping(CiTestCase):
+    @mock.patch("curtin.block.mkfs.distro.lsb_release",
+                mock.Mock(return_value={"codename": "resolute"}))
+    def test_unsupported_fs_family(self):
+        with self.assertRaisesRegex(
+                ValueError, "flag 'quiet' not supported by fs family 'btrfs'"):
+            mkfs.get_flag_mapping("quiet", "btrfs", strict=True)
+
 # vi: ts=4 expandtab syntax=python


### PR DESCRIPTION
The `ValueError(str-format % arg1, arg2)` instruction does not result in arg2 being consumed by the % operator. Instead, arg2 is passed as the second argument of ValueError, causing a TypeError issue at runtime.

We need parentheses to make sure arg2 is consumed by the % operator.