### PR TITLE
Fix typos in user facing docs and errors

### DIFF
--- a/README
+++ b/README
@@ -1,9 +1,9 @@
 This is 'curtin', the curt installer.  It is blunt, brief, snappish, snippety
 and unceremonious.
 
-Its goal is to install an operating system as quick as possible.
+Its goal is to install an operating system as quickly as possible.
 
 The canonical location of the source code is at
 https://github.com/canonical/curtin
-- the launchpad mirror should not have new merge proposal opened, and exising
+- the launchpad mirror should not have new merge proposal opened, and existing
   launchpad merge proposals will be manually merged or closed.

--- a/curtin/block/clear_holders.py
+++ b/curtin/block/clear_holders.py
@@ -178,7 +178,7 @@ def shutdown_mdadm(device):
     blockdev = block.sysfs_to_devpath(device)
 
     if mdadm.md_is_in_container(blockdev):
-        LOG.info('Array is in a container, skip discovering ' +
+        LOG.info('Array is in a container, skipping discovery of ' +
                  'raid devices and spares for %s', device)
         md_devs = []
     else:
@@ -444,7 +444,7 @@ def get_holders(device):
 
 def gen_holders_tree(device):
     """
-    generate a tree representing the current storage hirearchy above 'device'
+    generate a tree representing the current storage hierarchy above 'device'
     """
     device = block.sys_block_path(device)
     dev_name = block.path_to_kname(device)
@@ -482,7 +482,7 @@ def plan_shutdown_holder_trees(holders_trees):
     their path in /sys/block and their dev type
 
     can accept either a single storage tree or a list of storage trees assumed
-    to start at an equal place in storage hirearchy (i.e. a list of trees
+    to start at an equal place in storage hierarchy (i.e. a list of trees
     starting from disk)
     """
     # holds a temporary registry of holders to allow cross references

--- a/curtin/block/mdadm.py
+++ b/curtin/block/mdadm.py
@@ -393,7 +393,7 @@ def zero_device(devpath, force=False):
     assert_valid_devpath(devpath)
     metadata = mdadm_examine(devpath, export=False)
     if not metadata and not force:
-        LOG.debug('%s not mdadm member, force=False so skiping zeroing',
+        LOG.debug('%s not mdadm member, force=False so skipping zeroing',
                   devpath)
         return
     LOG.debug('mdadm.examine metadata:\n%s', util.json_dumps(metadata))

--- a/curtin/commands/apt_config.py
+++ b/curtin/commands/apt_config.py
@@ -596,7 +596,7 @@ def _generate_sources_list_compat(
     from_file = False
     if tmpl is None:
         LOG.info("No custom template provided, fall back to modify"
-                 "mirrors in %s on the target system", aptsrc)
+                 " mirrors in %s on the target system", aptsrc)
         tmpl = util.load_file(paths.target_path(target, aptsrc))
         from_file = True
 
@@ -627,7 +627,7 @@ def _generate_sources_deb822(cfg, release, mirrors, target=None, arch=None):
 
     if tmpl is None:
         LOG.info('No custom template provided, fall back to modify'
-                 'mirrors in %s on the target system', sources_deb822)
+                 ' mirrors in %s on the target system', sources_deb822)
 
         # If we don't already have the deb82 sources file, we will need to read
         # from sources.list and do the migration.

--- a/curtin/commands/block_meta.py
+++ b/curtin/commands/block_meta.py
@@ -395,7 +395,7 @@ def make_dname(volume, storage_config):
     sanitized = sanitize_dname(dname)
     if sanitized != dname:
         LOG.warning("dname modified to remove invalid chars. old:"
-                    "'%s' new: '%s'", dname, sanitized)
+                    " '%s' new: '%s'", dname, sanitized)
     content = ['# Written by curtin']
     for match in matches:
         rule = (base_rule + match +
@@ -1222,7 +1222,7 @@ def format_handler(info, storage_config, context):
     mkfs.mkfs_from_config(volume_path, info)
 
     device_type = storage_config.get(volume).get('type')
-    LOG.debug('Formated device type: %s', device_type)
+    LOG.debug('Formatted device type: %s', device_type)
     if device_type == 'bcache':
         # other devs have a udev watch on them. Not bcache (LP: #1680597).
         LOG.debug('Detected bcache device format, calling udevadm trigger to '
@@ -1264,7 +1264,7 @@ def mount_data(info, storage_config):
     else:
         if info['device'] not in storage_config:
             raise ValueError(
-                "mount entry refers to non-existant device %s: (%s)" %
+                "mount entry refers to non-existent device %s: (%s)" %
                 (info['device'], info))
         if not (fstype and spec):
             format_info = storage_config.get(info['device'])
@@ -1273,7 +1273,7 @@ def mount_data(info, storage_config):
             if not spec:
                 if format_info.get('volume') not in storage_config:
                     raise ValueError(
-                        "format type refers to non-existant id %s: (%s)" %
+                        "format type refers to non-existent id %s: (%s)" %
                         (format_info.get('volume'), format_info))
                 volume_path = get_path_to_storage_volume(
                     format_info['volume'],  storage_config)
@@ -1691,7 +1691,7 @@ def dm_crypt_handler(info, storage_config, context):
         zkey_used = None
         if block.zkey_supported(strict=False):
             volume_name = "%s:%s" % (volume_byid_path, dm_name)
-            LOG.debug('Attempting to setup zkey for %s', volume_name)
+            LOG.debug('Attempting to set up zkey for %s', volume_name)
             luks_type = 'luks2'
             gen_cmd = ['zkey', 'generate', '--xts', '--volume-type', luks_type,
                        '--sector-size', '4096', '--name', dm_name,
@@ -1768,9 +1768,9 @@ def dm_crypt_handler(info, storage_config, context):
             omode="a",
         )
     else:
-        LOG.info("fstab configuration is not present in environment, so \
-            cannot locate an appropriate directory to write crypttab in \
-            so not writing crypttab")
+        LOG.info("fstab configuration is not present in environment, so"
+                 " cannot locate an appropriate directory to write"
+                 " crypttab in, so not writing crypttab")
 
 
 def verify_md_components(md_devname, raidlevel, device_paths, spare_paths,
@@ -1884,9 +1884,9 @@ def raid_handler(info, storage_config, context):
         mdadm_scan_data = mdadm.mdadm_detail_scan()
         util.write_file(mdadm_location, mdadm_scan_data)
     else:
-        LOG.info("fstab configuration is not present in the environment, so \
-            cannot locate an appropriate directory to write mdadm.conf in, \
-            so not writing mdadm.conf")
+        LOG.info("fstab configuration is not present in the environment, so"
+                 " cannot locate an appropriate directory to write"
+                 " mdadm.conf in, so not writing mdadm.conf")
 
     # If ptable is specified, call disk_handler on this mdadm device to create
     # the table
@@ -2296,7 +2296,7 @@ def meta_custom(args):
             try:
                 handler(command, storage_config_dict, context)
             except Exception as error:
-                LOG.error("An error occured handling '%s': %s - %s" %
+                LOG.error("An error occurred handling '%s': %s - %s" %
                           (item_id, type(error).__name__, error))
                 raise
 

--- a/curtin/commands/curthooks.py
+++ b/curtin/commands/curthooks.py
@@ -461,9 +461,9 @@ def uefi_remove_old_loaders(bootcfg: config.BootCfg, target: str):
                     ['efibootmgr', '-B', '-b', number], capture=True)
     else:
         LOG.debug(
-            "Skipped removing %d old UEFI entrie%s.",
+            "Skipped removing %d old UEFI entr%s.",
             len(old_efi_entries),
-            '' if len(old_efi_entries) == 1 else 's')
+            'y' if len(old_efi_entries) == 1 else 'ies')
         for entry in old_efi_entries.values():
             LOG.debug(
                 "UEFI entry '%s' might no longer exist and "

--- a/curtin/commands/curthooks.py
+++ b/curtin/commands/curthooks.py
@@ -439,7 +439,7 @@ def uefi_remove_old_loaders(bootcfg: config.BootCfg, target: str):
     """Removes the old UEFI loaders from efibootmgr."""
     efi_state = util.get_efibootmgr(target)
 
-    LOG.debug('UEFI remove old olders efi state:\n%s', efi_state)
+    LOG.debug('UEFI remove old loaders efi state:\n%s', efi_state)
 
     old_efi_entries = {
         number: entry
@@ -497,7 +497,7 @@ def _reorder_new_entry(
     target = []
 
     LOG.debug("UEFI previous boot order: %s", efi_orig.order)
-    LOG.debug("UEFI current  boot order: %s", efi_state.order)
+    LOG.debug("UEFI current boot order: %s", efi_state.order)
     new_entries = list(set(efi_state.order).difference(set(efi_orig.order)))
     if new_entries:
         LOG.debug("UEFI Found new boot entries: %s", new_entries)
@@ -1004,7 +1004,7 @@ def update_initramfs(target=None, all_kernels=False):
         # Curtin only knows update-initramfs (provided by initramfs-tools) and
         # dracut.
         if not list(paths.get_kernel_list(target)):
-            LOG.debug("neither update-initramfs or dracut found in target %s"
+            LOG.debug("neither update-initramfs nor dracut found in target %s"
                       " but there is no initramfs to generate, so ignoring",
                       target)
         else:

--- a/curtin/commands/net_meta.py
+++ b/curtin/commands/net_meta.py
@@ -121,7 +121,7 @@ def net_meta(args):
         with open(t_eni, "r") as fp:
             content = fp.read()
         LOG.warning("net-meta mode is 'copy', static network interfaces files"
-                    "can be brittle.  Copied interfaces: %s", content)
+                    " can be brittle.  Copied interfaces: %s", content)
         target = args.output
 
     elif args.mode == "dhcp":

--- a/curtin/storage_config.py
+++ b/curtin/storage_config.py
@@ -251,7 +251,7 @@ def _validate_dep_type(source_id, dep_key, dep_id, sconfig):
         s_str = '%s(id=%s).%s' % (source_type.capitalize(),
                                   source_id, dep_key)
         d_str = '%s(id=%s)' % (dep_type.capitalize(), dep_id)
-        dep_chain = "%s cannot depend upon on %s" % (s_str, d_str)
+        dep_chain = "%s cannot depend on %s" % (s_str, d_str)
         raise ValueError(dep_chain)
 
     return result
@@ -345,7 +345,7 @@ def merge_config_trees_to_list(config_trees):
             max_level = level
         item_cfg = tree[top_item_id]
         if top_item_id in reg:
-            LOG.warning('Dropping Duplicate id: %s' % top_item_id)
+            LOG.warning('Dropping duplicate id: %s' % top_item_id)
             continue
         reg[top_item_id] = {'level': level, 'config': item_cfg}
 

--- a/curtin/swap.py
+++ b/curtin/swap.py
@@ -220,7 +220,7 @@ def is_swap_device(path):
     magic_offset = pagesize - 10
     size = util.file_size(path)
     if size < magic_offset:
-        LOG.debug("%s is to small for swap (size=%d < pagesize=%d)",
+        LOG.debug("%s is too small for swap (size=%d < pagesize=%d)",
                   path, size, pagesize)
         return False
     magic = util.load_file(

--- a/curtin/util.py
+++ b/curtin/util.py
@@ -1106,8 +1106,8 @@ def sanitize_source(source):
 
     elif source.startswith("squashfs:"):
         LOG.warning("The squashfs: prefix is deprecated and"
-                    "will be removed in a future release."
-                    "Please use squashfs:// instead.")
+                    " will be removed in a future release."
+                    " Please use squashfs:// instead.")
         return {'type': 'fsimage', 'uri': source[len("squashfs:"):]}
 
     if source.endswith("squashfs") or source.endswith("squash"):

--- a/doc/devel/clear_holders_doc.txt
+++ b/doc/devel/clear_holders_doc.txt
@@ -10,7 +10,6 @@ a holders_tree node are:
       - crypt
       - raid
       - bcache
-      - disk
   - name: the kname of the device (used for display)
   - holders: holders_trees for devices depending on the current device
 
@@ -43,7 +42,6 @@ list of dictionaries, with each dictionary containing the keys:
       - crypt
       - raid
       - bcache
-      - disk
   - level: the level of the device in the current storage hierarchy
            (starting from 0)
 

--- a/doc/devel/clear_holders_doc.txt
+++ b/doc/devel/clear_holders_doc.txt
@@ -1,8 +1,8 @@
 The new version of clear_holders is based around a data structure called a
-holder_tree which represents the current storage hirearchy above a specified
+holder_tree which represents the current storage hierarchy above a specified
 starting device. Each node in a holders tree contains data about the node and a
 key 'holders' which contains a list of all nodes that depend on it. The keys in
-a holdres_tree node are:
+a holders_tree node are:
   - device: the path to the device in /sys/class/block
   - dev_type: what type of storage layer the device is. possible values:
       - disk
@@ -33,7 +33,7 @@ The logic to plan what order to shut down storage layers in is in
 clear_holders.plan_shutdown_holders_trees. This function accepts either a
 single holders tree or a list of holders trees. When run with a list of holders
 trees, it assumes that all of these trees start at basically the same layer in
-the overall storage hirearcy for the system (i.e. a list of holders trees
+the overall storage hierarchy for the system (i.e. a list of holders trees
 starting from all of the target installation disks). This function returns a
 list of dictionaries, with each dictionary containing the keys:
   - device: the path to the device in /sys/class/block
@@ -44,7 +44,7 @@ list of dictionaries, with each dictionary containing the keys:
       - raid
       - bcache
       - disk
-  - level: the level of the device in the current storage hirearchy
+  - level: the level of the device in the current storage hierarchy
            (starting from 0)
 
 The items in the list returned by clear_holders.plan_shutdown_holders_trees
@@ -54,7 +54,7 @@ The main interface for clear_holders is the function
 clear_holders.clear_holders. If the system has just been booted it could be
 beneficial to run the function clear_holders.start_clear_holders_deps before
 using clear_holders.clear_holders. This ensures clear_holders will be able to
-properly storage devices. The function clear_holders.clear_holders can be
+properly shut down storage devices. The function clear_holders.clear_holders can be
 passed either a single device or a list of devices and will shut down all
 storage devices above the device(s). The devices can be specified either by
 path in /dev or by path in /sys/class/block.
@@ -70,8 +70,8 @@ specified should be ready for partitioning.
 It is possible to query further information about storage devices using
 clear_holders.
 
-Holders for a individual device can be queried using clear_holders.get_holders.
-Results are returned as a list or knames for holding devices.
+Holders for an individual device can be queried using clear_holders.get_holders.
+Results are returned as a list of knames for holding devices.
 
 A holders tree can be printed in a human readable format using
 clear_holders.format_holders_tree(). Example output:

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -5,7 +5,7 @@
 
 Welcome to curtin's documentation!
 ==================================
-This is 'curtin', the curt installer.  It is blunt, brief, snappish, snippety and unceremonious.  Its goal is to install an operating system as quick as possible.
+This is 'curtin', the curt installer.  It is blunt, brief, snappish, snippety and unceremonious.  Its goal is to install an operating system as quickly as possible.
 
 Contents:
 

--- a/doc/topics/apt_source.rst
+++ b/doc/topics/apt_source.rst
@@ -50,7 +50,7 @@ The general configuration of the apt feature is under an element called ``apt``.
 This can have various "global" subelements as listed in the examples below.
 The file ``apt-source.yaml`` holds more examples.
 
-These global configurations are valid throughput all of the apt feature.
+These global configurations are valid throughout all of the apt feature.
 So for example a global specification of a ``primary`` mirror will apply to all rendered sources entries.
 
 Then there is a section ``sources`` which can hold any number of source subelements itself.
@@ -70,7 +70,7 @@ The values inside the entries consist of the following optional entries
 
 * ``keyserver``: specify an alternate keyserver to pull keys from that were specified by keyid
 
-The section "sources" is is a dictionary (unlike most block/net configs which are lists). This format allows merging between multiple input files than a list like ::
+The section "sources" is a dictionary (unlike most block/net configs which are lists). This format allows merging between multiple input files than a list like ::
 
   sources:
      s1: {'key': 'key1', 'source': 'source1'}
@@ -259,7 +259,7 @@ The file `examples/apt-source.yaml <https://github.com/canonical/curtin/blob/mas
 Timing
 ~~~~~~
 The feature is implemented at the stage of curthooks_commands, which runs just after curtin has extracted the image to the target.
-Additionally it can be ran as standalong command "curtin -v --config <yourconfigfile> apt-config".
+Additionally it can be ran as standalone command "curtin -v --config <yourconfigfile> apt-config".
 
 This will pick up the target from the environment variable that is set by curtin, if you want to use it to a different target or outside of usual curtin handling you can add ``--target <path>`` to it to overwrite the target path.
 This target should have at least a minimal system with apt, apt-add-repository and dpkg being installed for the functionality to work.
@@ -325,4 +325,4 @@ Versions of cloud-init present 16.04+ read the "new" style apt configuration, bu
     apt:
       preserve_sources_list: VALUE
 
-**Note**: If versions of cloud-init that support the new style config receive conflicting values in old style and new style, cloud-init will raise exception and exit failure.  It simplly doesn't know what behavior is desired.
+**Note**: If versions of cloud-init that support the new style config receive conflicting values in old style and new style, cloud-init will raise exception and exit failure.  It simply doesn't know what behavior is desired.

--- a/doc/topics/config.rst
+++ b/doc/topics/config.rst
@@ -275,7 +275,7 @@ This setting is ignored if *update_nvram* is False.
         - /dev/sda1
      probe_additional_os: True
 
-**Avoid writting any settings to etc/default/grub.d/50-curtin-settings.cfg**::
+**Avoid writing any settings to etc/default/grub.d/50-curtin-settings.cfg**::
 
   boot:
      bootloaders:
@@ -623,7 +623,7 @@ boot for systems with multipath.  Curtin does not apply any advanced
 configuration or tuning, rather it uses distro defaults and provides
 enough configuration to enable booting.
 
-**mode**: *<['auto', ['disabled']>*
+**mode**: *<['auto', 'disabled']>*
 
 Defaults to auto which will configure enough to enable booting on multipath
 devices.  Disabled will prevent curtin from installing or configuring
@@ -673,7 +673,7 @@ Mapping is a dictionary of key value pairs which will result in the string
 'key/value' being present in the pollinate user-agent string sent to the
 pollen server.
 
-Setting the ``user_agent`` value to false will disable writting of the
+Setting the ``user_agent`` value to false will disable writing of the
 user-agent string.
 
 **Example**::
@@ -801,7 +801,7 @@ Example::
 
 **Layer Dependencies**
 
-Layers are parts of the name seperated by dots. Any layer in the name will
+Layers are parts of the name separated by dots. Any layer in the name will
 be included as a dependency. The file extension pattern is used to find
 related layers.
 
@@ -839,7 +839,7 @@ Examples:
 If there is a missing image in the path to a leaf, an error will be raised
 
  source='fsimage-layered://images/main.squashfs' -> images='/images/main.squashfs'
- source='fsimage-layered://images/main.upper.debug.squashfs' -> Raised Error'
+ source='fsimage-layered://images/main.upper.debug.squashfs' -> 'Raised Error'
 
  Remote Layers::
 
@@ -936,7 +936,7 @@ this stage does nothing.
       99-cmd:  ['echo', 'I ran last']
       00-cmd:  ['echo', 'I ran first']
   late_commands:
-      50-cmd: ['curtin', 'in-target' '--', 'touch', '/etc/disable_overlayroot']
+      50-cmd: ['curtin', 'in-target', '--', 'touch', '/etc/disable_overlayroot']
     
 
 swap
@@ -975,7 +975,7 @@ In some target filesystems, e.g. btrfs, xfs, zfs, the use of a swap file has
 restrictions.  If curtin detects that there may be issues it will refuse
 to create the swapfile.  Users can force creation of a swapfile by passing
 ``force: true``.  A forced swapfile may not be used by the target OS and could
-log cause an error.
+cause an error.
 
 **Example**::
 

--- a/doc/topics/curthooks.rst
+++ b/doc/topics/curthooks.rst
@@ -34,7 +34,7 @@ Image provided curtin-hooks
 An image provides curtin hooks support by containing a file
 ``/curtin/curtin-hooks``.
 
-If an Ubuntu image image contains this path it will override the builtin
+If an Ubuntu image contains this path it will override the builtin
 curtin support.
 
 The ``curtin-hooks`` program should be executable in the filesystem and

--- a/doc/topics/integration-testing.rst
+++ b/doc/topics/integration-testing.rst
@@ -86,7 +86,7 @@ At step 7 you might want to take a look at the output disk yourself.  It is a
 normal qcow image, so one can use ``mount-image-callback`` as described above.
 
 To invoke xkvm on your own take the command you see in the output and remove
-the "-serial ..." but add ``-nographic`` instead For graphical console one can
+the "-serial ..." but add ``-nographic`` instead. For graphical console one can
 add ``--vnc 127.0.0.1:1``
 
 Setup
@@ -318,8 +318,8 @@ Some environment variables affect the running of vmtest
 - ``CURTIN_VMTEST_ADD_REPOS``: default ''
    This is a comma delimited list of apt repositories that will be
    added to the target environment.  If there are repositories
-   provided here, the and CURTIN_VMTEST_SYSTEM_UPGRADE is at its default
-   setting (auto), then a upgrade will be done to make sure to include
+   provided here and CURTIN_VMTEST_SYSTEM_UPGRADE is at its default
+   setting (auto), then an upgrade will be done to make sure to include
    any new packages.
 
    The string 'proposed' is handled specially.  It will enable the

--- a/doc/topics/networking.rst
+++ b/doc/topics/networking.rst
@@ -40,7 +40,7 @@ the key ``subnets``.
 Physical
 ~~~~~~~~
 The ``physical`` type configuration represents a "physical" network device,
-typically Ethernet-based.  At least one of of these entries is required for
+typically Ethernet-based.  At least one of these entries is required for
 external network connectivity.  Type ``physical`` requires only one key:
 ``name``.  A ``physical`` device may contain some or all of the following keys:
 
@@ -233,14 +233,14 @@ Valid keys are:
           - jumbo0
         params:
           bridge_ageing: 250
-		  bridge_bridgeprio: 22
-		  bridge_fd: 1
+          bridge_bridgeprio: 22
+          bridge_fd: 1
           bridge_hello: 1
           bridge_maxage: 10
           bridge_maxwait: 0
           bridge_pathcost:
             - jumbo0 75
-          bridge_pathprio:
+          bridge_portprio:
             - jumbo0 28
           bridge_stp: 'off'
           bridge_maxwait:
@@ -278,7 +278,7 @@ Users can specify a ``nameserver`` type.  Nameserver dictionaries include
 the following keys:
 
 - ``address``: List of IPv4 or IPv6 address of nameservers.
-- ``search``: List of of hostnames to include in the resolv.conf search path.
+- ``search``: List of hostnames to include in the resolv.conf search path.
 
 **Nameserver Example**::
 
@@ -336,14 +336,14 @@ For any network device (one of the Config Types) users can define a list of
 entries will create interface alias allowing a single interface to use different
 ip configurations.  
 
-Valid keys for for ``subnets`` include the following:
+Valid keys for ``subnets`` include the following:
 
 - ``type``: Specify the subnet type.
 - ``control``: Specify manual, auto or hotplug.  Indicates how the interface will be handled during boot.
 - ``address``: IPv4 or IPv6 address.  It may include CIDR netmask notation.
 - ``netmask``: IPv4 subnet mask in dotted format or CIDR notation.
 - ``gateway``: IPv4 address of the default gateway for this subnet.
-- ``dns_nameserver``: Specify a list of IPv4 dns server IPs to end up in resolv.conf.
+- ``dns_nameservers``: Specify a list of IPv4 dns server IPs to end up in resolv.conf.
 - ``dns_search``: Specify a list of search paths to be included in resolv.conf.
 
 

--- a/doc/topics/overview.rst
+++ b/doc/topics/overview.rst
@@ -2,7 +2,7 @@
 Overview
 ========
 
-Curtin is intended to be a bare bones "installer".   Its goal is to take data from a source, and get it onto disk as quick as possible and then boot it.  The key difference from traditional package based installers is that curtin assumes the thing its installing is intelligent and will do the right thing.
+Curtin is intended to be a bare bones "installer".   Its goal is to take data from a source, and get it onto disk as quickly as possible and then boot it.  The key difference from traditional package based installers is that curtin assumes the thing it's installing is intelligent and will do the right thing.
 
 .. _Stages:
 

--- a/doc/topics/reporting.rst
+++ b/doc/topics/reporting.rst
@@ -7,11 +7,11 @@ This enables the user to obtain status information from curtin.
 
 Events
 ------
-Reporting consists of notification of a series of 'events.  Each event has:
+Reporting consists of notification of a series of 'events'.  Each event has:
  - **event_type**: 'start' or 'finish'
  - **description**: human readable text
  - **level**: the log level of the event, DEBUG/INFO/WARN etc.
- - **name**: and id for this event
+ - **name**: an id for this event
  - **result**: only present when event_type is 'finish', its value is one of "SUCCESS", "WARN", or "FAIL".  A result of WARN indicates something is likely wrong, but a non-fatal error.  A result of "FAIL" is fatal.
  - **origin**: literal value 'curtin'
  - **timestamp**: the unix timestamp at which this event occurred

--- a/doc/topics/storage.rst
+++ b/doc/topics/storage.rst
@@ -70,7 +70,7 @@ commands include:
 - RAID Command (``raid``)
 - Bcache Command (``bcache``)
 - Zpool Command (``zpool``) **Experimental**
-- ZFS Command (``zfs``)) **Experimental**
+- ZFS Command (``zfs``) **Experimental**
 - NVMe Controller Command (``nvme_controller``) **Experimental**
 - Device "Command" (``device``)
 
@@ -143,7 +143,7 @@ These ``label`` values are reserved and cannot be used:
 
 **disk_layout**: *cdl, ldl*
 
-The default ``disk_layout`` value is ``cdl``, the compaible disk layout which
+The default ``disk_layout`` value is ``cdl``, the compatible disk layout which
 allows for up to 3 partitions and a VTOC.  The ``ldl``, Linux layout has only
 one partition.
 
@@ -420,7 +420,7 @@ it has already been processed.
 **wipe**: *superblock, superblock-recursive, pvremove, zero, random*
 
 After the partition is added to the disk's partition table, curtin can run a
-wipe command on the partition. The wipe command values are the sames as for
+wipe command on the partition. The wipe command values are the same as for
 disks.
 
 .. note::
@@ -437,7 +437,7 @@ only apply to gpt partition tables.
 
 The *logical/extended* partition flags can be used to create logical partitions
 on a msdos table. An extended partition should be created containing all of the
-empty space on the drive, and logical partitions can be created within it. A
+empty space on the drive, and logical partitions can be created within it. An
 extended partition must already be present to create logical partitions.
 
 On msdos partition tables, the *boot* flag sets the boot parameter to
@@ -547,7 +547,7 @@ target volume can be specified, as well as a few other options.
 .. note::
 
   Filesystems support for ZFS on root is **Experimental**.
-  Utilizing the the ``fstype: zfsroot`` will indicate to curtin
+  Utilizing the ``fstype: zfsroot`` will indicate to curtin
   that it should automatically inject the appropriate ``type: zpool``
   and ``type: zfs`` command structures based on which target ``volume``
   is specified in the ``format`` command.  There may be only *one*
@@ -798,7 +798,7 @@ with ``name`` *lv1* on a ``lvm_volgroup`` named *vg1* would have the path
 
 .. note::
 
-   dname values for contructed devices (such as lvm) only remain persistent
+   dname values for constructed devices (such as lvm) only remain persistent
    as long as the device metadata does not change.  If users modify the device
    such that device metadata is changed then the udev rule may no longer apply.
 
@@ -833,7 +833,7 @@ the lvm partition.
 
 .. note::
 
-  Curtin does not adjust size values.  If you specific a size that exceeds the 
+  Curtin does not adjust size values.  If you specify a size that exceeds the
   capacity of a device then installation will fail.
 
 
@@ -948,7 +948,7 @@ The ``name`` key specifies the name of the md device.
   Curtin creates a udev rule to create a link to the md device in
   ``/dev/disk/by-dname/<name>`` using the specified name.  The dname
   symbolic link is only persistent as long as the raid metadata is
-  not modifed or destroyed.
+  not modified or destroyed.
 
 **raidlevel**: *0, 1, 5, 6, 10*
 
@@ -1053,7 +1053,7 @@ If the ``name`` key is present, curtin will create a link to the device at
 
 .. note::
 
-   dname values for contructed devices (such as bcache) only remain persistent
+   dname values for constructed devices (such as bcache) only remain persistent
    as long as the device metadata does not change.  If users modify the device
    such that device metadata is changed then the udev rule may no longer apply.
 


### PR DESCRIPTION
These are mostly typos or missing word splitting in docs and error messages.

The few things that stand out are fixes in the docs where wrong property names were used (e.g. `dns_nameservers` & `bridge_portprio`).
