### PR TITLE
doc: drop dangling reference to HACKING.rst

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -19,7 +19,6 @@ Contents:
    topics/storage
    topics/curthooks
    topics/reporting
-   topics/hacking
    topics/integration-testing
 
 

--- a/doc/topics/hacking.rst
+++ b/doc/topics/hacking.rst
@@ -1,2 +1,0 @@
-.. include:: ../../HACKING.rst
-.. vi: textwidth=78


### PR DESCRIPTION
`HACKING.rst` was replaced by `CONTRIBUTING.md` in https://github.com/canonical/curtin/pull/14 and this created a dangling reference.

Contributors can read the contributing guide from Github so let's get rid of the references.

