### PR TITLE
Noble backports May 2026

### DIFF
--- a/curtin/block/clear_holders.py
+++ b/curtin/block/clear_holders.py
@@ -136,9 +136,13 @@ def shutdown_lvm(device):
     # (corresponding to the "lv_dm_path" property), let's use this one instead.
     dm_path = os.path.join("/dev/mapper/", lvm_name)
 
-    # wipe contents of the logical volume first
-    LOG.info('Wiping lvm logical volume: %s (%s)', dm_path, vg_lv_name)
-    block.quick_zero(dm_path, partitions=False)
+    if util.load_file(os.path.join(device, 'ro')).strip() == '0':
+        # wipe contents of the logical volume first
+        LOG.info('Wiping lvm logical volume: %s (%s)', dm_path, vg_lv_name)
+        block.quick_zero(dm_path, partitions=False)
+    else:
+        LOG.info("%s (%s) is read-only, skipping attempt to wipe device",
+                 dm_path, vg_lv_name)
 
     # remove the logical volume
     LOG.debug('using "lvremove" on %s', vg_lv_name)

--- a/curtin/block/clear_holders.py
+++ b/curtin/block/clear_holders.py
@@ -127,11 +127,18 @@ def shutdown_lvm(device):
     lvm_name = util.load_file(name_file).strip()
     (vg_name, lv_name) = lvm.split_lvm_name(lvm_name)
     vg_lv_name = "%s/%s" % (vg_name, lv_name)
-    devname = "/dev/" + vg_lv_name
+
+    # Normal LV-s have a symlink in /dev/{vgname}/{lvname} which corresponds to
+    # the "lv_path" property. This path is what we previously used for wiping.
+    # However, other types of LV-s (such as thin-pools) don't have this
+    # symlink.
+    # Since both types of LV have a /dev/mapper/{vgname}-{lvname} symlink
+    # (corresponding to the "lv_dm_path" property), let's use this one instead.
+    dm_path = os.path.join("/dev/mapper/", lvm_name)
 
     # wipe contents of the logical volume first
-    LOG.info('Wiping lvm logical volume: %s', devname)
-    block.quick_zero(devname, partitions=False)
+    LOG.info('Wiping lvm logical volume: %s (%s)', dm_path, vg_lv_name)
+    block.quick_zero(dm_path, partitions=False)
 
     # remove the logical volume
     LOG.debug('using "lvremove" on %s', vg_lv_name)

--- a/curtin/block/lvm.py
+++ b/curtin/block/lvm.py
@@ -29,9 +29,11 @@ def _filter_lvm_info(lvtool, match_field, query_field, match_key, args=None):
 
 def get_pvols_in_volgroup(vg_name):
     """
-    get physical volumes used by volgroup
+    get physical volumes used by volgroup (excluding missing ones)
     """
-    return _filter_lvm_info('pvdisplay', 'vg_name', 'pv_name', vg_name)
+    pvs = _filter_lvm_info('pvdisplay', 'vg_name', 'pv_name', vg_name)
+    # filter out missing PVs (LP: #2142196)
+    return [pv for pv in pvs if pv != '[unknown]']
 
 
 def get_lvols_in_volgroup(vg_name):

--- a/curtin/storage_config.py
+++ b/curtin/storage_config.py
@@ -1046,7 +1046,11 @@ class LvmParser(ProbertParser):
                     errors.append(e)
                     continue
                 configs.append(entry)
-        for lv_name, lv_config in self.class_data['logical_volumes'].items():
+
+        # If there are VGs but none of them has a LV, probert can omit the
+        # "logical_volumes" key.
+        lvs = self.class_data.get('logical_volumes', {})
+        for lv_name, lv_config in lvs.items():
             entry = self.lvm_partition_asdict(lv_name, lv_config)
             if entry:
                 try:

--- a/tests/unittests/test_block_lvm.py
+++ b/tests/unittests/test_block_lvm.py
@@ -41,6 +41,12 @@ class TestBlockLvm(CiTestCase):
                                            query_name, 'bad_match_val')
         self.assertEqual(len(result_list), 0)
 
+    def test_get_pvols_in_volgroup__missing_pv(self):
+        with mock.patch('curtin.block.lvm._filter_lvm_info',
+                        return_value=['/dev/sda', '[unknown]', '/dev/sdb']):
+            self.assertEqual(['/dev/sda', '/dev/sdb'],
+                             lvm.get_pvols_in_volgroup('ubuntu-vg'))
+
     @mock.patch('curtin.block.lvm._filter_lvm_info')
     def test_get_lvm_info(self, mock_filter_lvm_info):
         """

--- a/tests/unittests/test_clear_holders.py
+++ b/tests/unittests/test_clear_holders.py
@@ -182,8 +182,8 @@ class TestClearHolders(CiTestCase):
         lvm_name = 'ubuntu--vg-swap'
         vg_name = 'ubuntu-vg'
         lv_name = 'swap'
-        vg_lv_name = "%s/%s" % (vg_name, lv_name)
-        devname = "/dev/" + vg_lv_name
+        vg_lv_name = "ubuntu-vg/swap"
+        dm_path = "/dev/mapper/ubuntu--vg-swap"
         pvols = ['/dev/wda1', '/dev/wda2']
         mock_syspath.return_value = self.test_blockdev
         mock_util.load_file.return_value = lvm_name
@@ -192,7 +192,7 @@ class TestClearHolders(CiTestCase):
         clear_holders.shutdown_lvm(self.test_blockdev)
         mock_syspath.assert_called_with(self.test_blockdev)
         mock_util.load_file.assert_called_with(self.test_blockdev + '/dm/name')
-        mock_zero.assert_called_with(devname, partitions=False)
+        mock_zero.assert_called_with(dm_path, partitions=False)
         mock_lvm.split_lvm_name.assert_called_with(lvm_name.strip())
         self.assertTrue(mock_log.debug.called)
         mock_util.subp.assert_called_with(

--- a/tests/unittests/test_clear_holders.py
+++ b/tests/unittests/test_clear_holders.py
@@ -186,12 +186,17 @@ class TestClearHolders(CiTestCase):
         dm_path = "/dev/mapper/ubuntu--vg-swap"
         pvols = ['/dev/wda1', '/dev/wda2']
         mock_syspath.return_value = self.test_blockdev
-        mock_util.load_file.return_value = lvm_name
+        mock_util.load_file.side_effect = (lvm_name, '0\n')
         mock_lvm.split_lvm_name.return_value = (vg_name, lv_name)
         mock_lvm.get_lvols_in_volgroup.return_value = ['lvol2']
         clear_holders.shutdown_lvm(self.test_blockdev)
         mock_syspath.assert_called_with(self.test_blockdev)
-        mock_util.load_file.assert_called_with(self.test_blockdev + '/dm/name')
+        expected_load_file_calls = [
+            mock.call(self.test_blockdev + '/dm/name'),
+            mock.call(self.test_blockdev + '/ro'),
+        ]
+        self.assertEqual(expected_load_file_calls,
+                         mock_util.load_file.mock_calls)
         mock_zero.assert_called_with(dm_path, partitions=False)
         mock_lvm.split_lvm_name.assert_called_with(lvm_name.strip())
         self.assertTrue(mock_log.debug.called)
@@ -201,12 +206,46 @@ class TestClearHolders(CiTestCase):
         self.assertEqual(len(mock_util.subp.call_args_list), 1)
         mock_lvm.get_lvols_in_volgroup.return_value = []
         self.assertTrue(mock_lvm.lvm_scan.called)
+        mock_util.load_file.side_effect = (lvm_name, '0\n')
         mock_lvm.get_pvols_in_volgroup.return_value = pvols
         clear_holders.shutdown_lvm(self.test_blockdev)
         mock_util.subp.assert_called_with(
             ['vgremove', '--force', '--force', vg_name], rcs=[0, 5])
         for pv in pvols:
             mock_zero.assert_any_call(pv, partitions=False)
+        self.assertTrue(mock_lvm.lvm_scan.called)
+
+    @mock.patch('curtin.block.quick_zero')
+    @mock.patch('curtin.block.clear_holders.LOG')
+    @mock.patch('curtin.block.clear_holders.block.sys_block_path')
+    @mock.patch('curtin.block.clear_holders.lvm')
+    @mock.patch('curtin.block.clear_holders.util')
+    def test_shutdown_lvm__thin_pool(self, mock_util, mock_lvm, mock_syspath,
+                                     mock_log, mock_zero):
+        """test clear_holders.shutdown_lvm when given a thin pool"""
+        lvm_name = 'pve-data'
+        vg_name = 'pve'
+        lv_name = 'data'
+        vg_lv_name = "pve/data"
+        mock_syspath.return_value = self.test_blockdev
+        mock_util.load_file.side_effect = (lvm_name, '1\n')
+        mock_lvm.split_lvm_name.return_value = (vg_name, lv_name)
+        mock_lvm.get_lvols_in_volgroup.return_value = ['lvol2']
+        clear_holders.shutdown_lvm(self.test_blockdev)
+        mock_syspath.assert_called_with(self.test_blockdev)
+        expected_load_file_calls = [
+            mock.call(self.test_blockdev + '/dm/name'),
+            mock.call(self.test_blockdev + '/ro'),
+        ]
+        self.assertEqual(expected_load_file_calls,
+                         mock_util.load_file.mock_calls)
+        # We skipped it because the device is read-only
+        mock_zero.assert_not_called()
+        mock_lvm.split_lvm_name.assert_called_with(lvm_name.strip())
+        self.assertTrue(mock_log.debug.called)
+        mock_util.subp.assert_called_with(
+            ['lvremove', '--force', '--force', vg_lv_name])
+        mock_util.subp.assert_called_once()
         self.assertTrue(mock_lvm.lvm_scan.called)
 
     @mock.patch('curtin.block.clear_holders.block')

--- a/tests/unittests/test_clear_holders.py
+++ b/tests/unittests/test_clear_holders.py
@@ -179,7 +179,7 @@ class TestClearHolders(CiTestCase):
     def test_shutdown_lvm(self, mock_util, mock_lvm, mock_syspath, mock_log,
                           mock_zero):
         """test clear_holders.shutdown_lvm"""
-        lvm_name = b'ubuntu--vg-swap\n'
+        lvm_name = 'ubuntu--vg-swap'
         vg_name = 'ubuntu-vg'
         lv_name = 'swap'
         vg_lv_name = "%s/%s" % (vg_name, lv_name)

--- a/tests/unittests/test_storage_config.py
+++ b/tests/unittests/test_storage_config.py
@@ -868,6 +868,18 @@ class TestLvmParser(CiTestCase):
         self.assertEqual(5, len(configs))
         self.assertEqual(0, len(errors))
 
+    @skipUnlessJsonSchema()
+    def test_lvm_parser_parse__vg_with_no_lv(self):
+        # Remove the logical_volumes key, to match what probert does when no LV
+        # is present.
+        del self.probe_data["lvm"]["logical_volumes"]
+        lvmp = LvmParser(self.probe_data)
+
+        configs, errors = lvmp.parse()
+
+        self.assertFalse(errors)
+        self.assertEqual(2, len(configs))
+
 
 class TestRaidParser(CiTestCase):
 


### PR DESCRIPTION
Backports to noble of:

* #19 - excluding the rewrite using `pvs` / `lvs` / `vgs` instead of `pvdisplay` / `lvdisplay` / `vgdisplay`
* #25
* #28

LP:#2107256
LP:#2143299
LP:#2142196

Some unit tests have been added that were not in the original PRs. I've opened https://github.com/canonical/curtin/pull/47 to get that sorted on main.
