### PR TITLE
curtin: replace comma-with-arg exception pattern with % formatting

### DIFF
--- a/curtin/block/bcache.py
+++ b/curtin/block/bcache.py
@@ -368,7 +368,7 @@ def validate_bcache_ready(bcache_device, bcache_sys_path):
                        'in slaves list %s' % slaves)
                 raise OSError(msg)
         else:
-            msg = 'didnt find "dev" attribute on: %s', bcache_dev
+            msg = 'didnt find "dev" attribute on: %s' % bcache_dev
             raise OSError(msg)
 
     else:
@@ -472,7 +472,7 @@ def create_backing_device(backing_device, cache_device, cache_mode, cset_uuid):
     bdir = os.path.join(backing_device_sysfs, "bcache")
     if os.path.exists(bdir):
         raise RuntimeError(
-            'Unexpected old bcache device: %s', backing_device)
+            'Unexpected old bcache device: %s' % backing_device)
 
     LOG.debug('Creating a backing device on %s', backing_device)
     util.subp(["make-bcache", "-B", backing_device])

--- a/curtin/block/clear_holders.py
+++ b/curtin/block/clear_holders.py
@@ -62,8 +62,8 @@ def shutdown_bcache(device):
     """
     if not device.startswith('/sys/class/block'):
         raise ValueError('Invalid Device (%s): '
-                         'Device path must start with /sys/class/block/',
-                         device)
+                         'Device path must start with /sys/class/block/'
+                         % device)
 
     # bcache device removal should be fast but in an extreme
     # case, might require the cache device to flush large
@@ -230,7 +230,7 @@ def shutdown_mdadm(device):
                 break
 
         if mdadm.md_present(block.path_to_kname(blockdev)):
-            raise OSError('Timeout exceeded for removal of %s', blockdev)
+            raise OSError('Timeout exceeded for removal of %s' % blockdev)
 
     except OSError:
         LOG.critical('Failed to stop mdadm device %s', device)

--- a/curtin/block/iscsi.py
+++ b/curtin/block/iscsi.py
@@ -315,7 +315,7 @@ def volpath_is_iscsi(volume_path):
         returns a boolean
     """
     if not volume_path:
-        raise ValueError("Invalid input for volume_path: '%s'", volume_path)
+        raise ValueError("Invalid input for volume_path: '%s'" % volume_path)
 
     volume_path_slaves = get_device_slave_knames(volume_path)
     LOG.debug('volume_path=%s found slaves: %s', volume_path,

--- a/curtin/block/mdadm.py
+++ b/curtin/block/mdadm.py
@@ -193,7 +193,7 @@ def mdadm_create(md_devname, raidlevel, devices, spares=None, container=None,
         holders = get_holders(device)
         if len(holders) > 0:
             LOG.warning('Detected holders during mdadm creation: %s', holders)
-            raise OSError('Failed to remove holders from %s', device)
+            raise OSError('Failed to remove holders from %s' % device)
         zero_device(device)
         cmd.append(device)
 
@@ -350,7 +350,7 @@ def mdadm_stop(devpath, retries=None):
             time.sleep(wait)
             pass
 
-    raise OSError('Failed to stop mdadm device %s', devpath)
+    raise OSError('Failed to stop mdadm device %s' % devpath)
 
 
 def mdadm_remove(devpath):
@@ -610,7 +610,7 @@ def __mdadm_detail_to_dict(input):
     if device:
         data.update({'device': device})
     else:
-        raise ValueError('Failed to determine device from input:\n%s', input)
+        raise ValueError('Failed to determine device from input:\n%s' % input)
 
     # start after the first newline
     remainder = input[input.find('\n')+1:]

--- a/curtin/block/zfs.py
+++ b/curtin/block/zfs.py
@@ -178,10 +178,10 @@ def _join_flags(optflag, params):
     """
 
     if not isinstance(optflag, str) or not optflag:
-        raise ValueError("Invalid optflag: %s", optflag)
+        raise ValueError("Invalid optflag: %s" % optflag)
 
     if not isinstance(params, dict):
-        raise ValueError("Invalid params: %s", params)
+        raise ValueError("Invalid params: %s" % params)
 
     # zfs flags and params require string booleans ('on', 'off')
     # yaml implicity converts those and others to booleans, we
@@ -206,7 +206,8 @@ def _join_pool_volume(poolname, volume):
     Combine poolname and volume.
     """
     if not poolname or not volume:
-        raise ValueError('Invalid pool (%s) or volume (%s)', poolname, volume)
+        raise ValueError('Invalid pool (%s) or volume (%s)'
+                         % (poolname, volume))
 
     return os.path.normpath("%s/%s" % (poolname, volume))
 
@@ -281,7 +282,7 @@ def zpool_create(poolname, vdevs, storage_config=None, context=None,
                                     invoking `zpool create`.
     """
     if not isinstance(poolname, util.string_types) or not poolname:
-        raise ValueError("Invalid poolname: %s", poolname)
+        raise ValueError("Invalid poolname: %s" % poolname)
 
     if isinstance(vdevs, util.string_types) or isinstance(vdevs, dict):
         raise TypeError("Invalid vdevs: expected list-like iterable")
@@ -345,10 +346,10 @@ def zfs_create(poolname, volume, zfs_properties=None, size=None):
                                     invoking `zfs create`.
     """
     if not isinstance(poolname, util.string_types) or not poolname:
-        raise ValueError("Invalid poolname: %s", poolname)
+        raise ValueError("Invalid poolname: %s" % poolname)
 
     if not isinstance(volume, util.string_types) or not volume:
-        raise ValueError("Invalid volume: %s", volume)
+        raise ValueError("Invalid volume: %s" % volume)
 
     zfs_cfg = {}
     if zfs_properties:
@@ -380,10 +381,10 @@ def zfs_mount(poolname, volume):
     """
 
     if not isinstance(poolname, util.string_types) or not poolname:
-        raise ValueError("Invalid poolname: %s", poolname)
+        raise ValueError("Invalid poolname: %s" % poolname)
 
     if not isinstance(volume, util.string_types) or not volume:
-        raise ValueError("Invalid volume: %s", volume)
+        raise ValueError("Invalid volume: %s" % volume)
 
     cmd = ['zfs', 'mount', _join_pool_volume(poolname, volume)]
     util.subp(cmd, capture=True)
@@ -411,7 +412,7 @@ def zpool_export(poolname):
     """
 
     if not isinstance(poolname, util.string_types) or not poolname:
-        raise ValueError("Invalid poolname: %s", poolname)
+        raise ValueError("Invalid poolname: %s" % poolname)
 
     util.subp(['zpool', 'export', poolname])
 

--- a/curtin/commands/block_meta.py
+++ b/curtin/commands/block_meta.py
@@ -921,7 +921,7 @@ def calc_partition_info(partition_kname, logical_block_size_bytes):
               partition_kname, p_size_sec, p_start_sec)
     if not all([p_size_sec, p_start_sec]):
         raise RuntimeError(
-            'Failed to determine partition %s info', partition_kname)
+            'Failed to determine partition %s info' % partition_kname)
 
     return (p_start_sec, p_size_sec)
 
@@ -1047,7 +1047,7 @@ def partition_handler(info, storage_config, context):
                        " and no extended partition '(type: partition, flag: "
                        "extended)' was found in the storage config.")
                 LOG.error(msg, info['id'])
-                raise RuntimeError(msg, info['id'])
+                raise RuntimeError(msg % info['id'])
             pnum = determine_partition_number(extended_part_id, storage_config)
         else:
             pnum = find_previous_partition(device, info['id'], storage_config)

--- a/curtin/commands/curthooks.py
+++ b/curtin/commands/curthooks.py
@@ -1544,7 +1544,7 @@ def inject_pollinate_user_agent_config(ua_cfg, target):
     user-agent file (/etc/pollinate/add-user-agent) in target.
     """
     if not isinstance(ua_cfg, dict):
-        raise ValueError('ua_cfg is not a dictionary: %s', ua_cfg)
+        raise ValueError('ua_cfg is not a dictionary: %s' % ua_cfg)
 
     pollinate_cfg = paths.target_path(target, '/etc/pollinate/add-user-agent')
     comment = "# written by curtin"

--- a/curtin/commands/install_grub.py
+++ b/curtin/commands/install_grub.py
@@ -54,14 +54,14 @@ def get_grub_package_name(target_arch, uefi, rhel_ver=None, osfamily=None):
                 grub_name = "grub2-efi-aa64"
                 grub_target = "arm64-efi"
             else:
-                raise ValueError('Unsupported RHEL version: %s', rhel_ver)
+                raise ValueError('Unsupported RHEL version: %s' % rhel_ver)
         elif osfamily == distro.DISTROS.suse:
             if target_arch == 'x86_64':
                 grub_target = "x86_64-efi"
             elif target_arch == 'aarch64':
                 grub_target = "arm64-efi"
             else:
-                raise ValueError('Unsupported SUSE arch: %s', target_arch)
+                raise ValueError('Unsupported SUSE arch: %s' % target_arch)
             grub_name = 'grub2-%s' % grub_target
         else:
             if target_arch == 'amd64':
@@ -88,11 +88,11 @@ def get_grub_package_name(target_arch, uefi, rhel_ver=None, osfamily=None):
                 elif int(rhel_ver) > 6:
                     grub_name = 'grub2-pc'
                 else:
-                    raise ValueError('Unsupported RHEL version: %s', rhel_ver)
+                    raise ValueError('Unsupported RHEL version: %s' % rhel_ver)
             elif target_arch == 'i386':
                 grub_name = 'grub-pc'
             else:
-                raise ValueError('Unsupported RHEL arch: %s', target_arch)
+                raise ValueError('Unsupported RHEL arch: %s' % target_arch)
         elif osfamily == distro.DISTROS.suse:
             grub_name = 'grub2-i386-pc'
         elif target_arch in ['i386', 'amd64']:

--- a/curtin/commands/net_meta.py
+++ b/curtin/commands/net_meta.py
@@ -36,7 +36,7 @@ def resolve_alias(alias):
         # should read /proc/cmdline here for BOOTIF
         raise NotImplementedError("netboot alias not implemented")
     else:
-        raise ValueError("'%s' is not an alias: %s", alias, DEVNAME_ALIASES)
+        raise ValueError("'%s' is not an alias: %s" % (alias, DEVNAME_ALIASES))
 
 
 def interfaces_basic_dhcp(devices, macs=None):

--- a/curtin/commands/pack.py
+++ b/curtin/commands/pack.py
@@ -30,8 +30,8 @@ def pack_main(args):
     addl = []
     for tok in args.add:
         if delim not in tok:
-            raise ValueError("'--add' argument '%s' did not have a '%s'",
-                             (tok, delim))
+            raise ValueError("'--add' argument '%s' did not have a '%s'"
+                             % (tok, delim))
         (archpath, filepath) = tok.split(":", 1)
         addl.append((archpath, filepath),)
 

--- a/curtin/distro.py
+++ b/curtin/distro.py
@@ -437,8 +437,8 @@ def system_upgrade(opts=None, target=None, env=None, allow_daemons=False,
                        'subcommands': ('refresh', 'update', 'purge-kernels',)},
     }
     if osfamily not in distro_cfg:
-        raise ValueError('Distro "%s" does not have system_upgrade support',
-                         osfamily)
+        raise ValueError('Distro "%s" does not have system_upgrade support'
+                         % osfamily)
 
     for mode in distro_cfg[osfamily]['subcommands']:
         ret = distro_cfg[osfamily]['function'](
@@ -599,8 +599,8 @@ def has_pkg_available(pkg, target=None, osfamily=None):
         osfamily = get_osfamily(target=target)
 
     if osfamily not in [DISTROS.debian, DISTROS.redhat, DISTROS.suse]:
-        raise ValueError('has_pkg_available: unsupported distro family: %s',
-                         osfamily)
+        raise ValueError('has_pkg_available: unsupported distro family: %s'
+                         % osfamily)
 
     if osfamily == DISTROS.suse:
         out, _ = subp(['zypper', '--quiet', 'search',

--- a/curtin/util.py
+++ b/curtin/util.py
@@ -351,7 +351,7 @@ def wait_for_removal(path, retries=[1, 3, 5, 7]):
         LOG.debug('%s has been removed', path)
         return
 
-    raise OSError('Timeout exceeded for removal of %s', path)
+    raise OSError('Timeout exceeded for removal of %s' % path)
 
 
 def load_command_environment(env=os.environ, strict=False):
@@ -375,7 +375,7 @@ def is_kmod_loaded(module):
     """Test if kernel module 'module' is current loaded by checking sysfs"""
 
     if not module:
-        raise ValueError('is_kmod_loaded: invalid module: "%s"', module)
+        raise ValueError('is_kmod_loaded: invalid module: "%s"' % module)
 
     return os.path.isdir('/sys/module/%s' % module)
 
@@ -386,7 +386,7 @@ def load_kernel_module(module, check_loaded=True):
     """
 
     if not module:
-        raise ValueError('load_kernel_module: invalid module: "%s"', module)
+        raise ValueError('load_kernel_module: invalid module: "%s"' % module)
 
     if check_loaded:
         if is_kmod_loaded(module):
@@ -1204,7 +1204,7 @@ def human2bytes(size):
 def bytes2human(size):
     """convert size in bytes to human readable"""
     if not isinstance(size, numeric_types):
-        raise ValueError('size must be a numeric value, not %s', type(size))
+        raise ValueError('size must be a numeric value, not %s' % type(size))
     isize = int(size)
     if isize != size:
         raise ValueError('size "%s" is not a whole number.' % size)


### PR DESCRIPTION
The pattern raise `SomeError("msg %s", val)` passes two arguments to the exception constructor instead of formatting the string, producing tuple repr like `('msg %s', 'val')` instead of readable formatted messages.

I'm happy to turn all of them to f-strings if wanted.