### PR TITLE
block: repair get_partition_sfdisk_info parameter shadowing

### DIFF
--- a/curtin/block/__init__.py
+++ b/curtin/block/__init__.py
@@ -310,15 +310,15 @@ def sfdisk_info(devpath):
     return {}
 
 
-def get_partition_sfdisk_info(devpath, sfdisk_info=None):
-    if not sfdisk_info:
-        sfdisk_info = sfdisk_info(devpath)
+def get_partition_sfdisk_info(devpath, sfdisk_info_data=None):
+    if not sfdisk_info_data:
+        sfdisk_info_data = sfdisk_info(devpath)
 
-    entry = [part for part in sfdisk_info['partitions']
+    entry = [part for part in sfdisk_info_data['partitions']
              if os.path.realpath(part['node']) == os.path.realpath(devpath)]
     if len(entry) != 1:
         raise RuntimeError('Device %s not present in sfdisk dump:\n%s' %
-                           (devpath, util.json_dumps(sfdisk_info)))
+                           (devpath, util.json_dumps(sfdisk_info_data)))
     return entry.pop()
 
 

--- a/tests/unittests/test_block.py
+++ b/tests/unittests/test_block.py
@@ -190,6 +190,17 @@ class TestBlock(CiTestCase):
                                     "not present in sfdisk dump"):
             block.get_partition_sfdisk_info("/dev/sda1", {"partitions": []})
 
+    @mock.patch('curtin.block.sfdisk_info')
+    @mock.patch('curtin.block.os.path.realpath',
+                mock.Mock(side_effect=lambda x: x))
+    def test_get_partition_sfdisk_info__no_passed_data(self, m_sfdisk_info):
+        devpath = "/dev/sda1"
+        expected_part = {"node": "/dev/sda1", "start": 2048, "size": 1000}
+        m_sfdisk_info.return_value = {"partitions": [expected_part]}
+        result = block.get_partition_sfdisk_info(devpath)
+        self.assertEqual(expected_part, result)
+        m_sfdisk_info.assert_called_once_with(devpath)
+
 
 class TestSysBlockPath(CiTestCase):
     @mock.patch("os.path.exists")


### PR DESCRIPTION
`get_partition_sfdisk_info(devpath, sfdisk_info=None)` declared a parameter named `'sfdisk_info'` that shadowed the module-level function of the same name. When called without the argument `sfdisk_info=None`, the line `sfdisk_info = sfdisk_info(devpath)` evaluated the right-hand side against the local parameter `None` instead of the module function, raising:

```python
TypeError: NoneType object is not callable
```

The function could never work with its default argument.