### PR TITLE
Resolve a few bugs identified by an LLM

### DIFF
--- a/curtin/commands/block_meta.py
+++ b/curtin/commands/block_meta.py
@@ -199,7 +199,7 @@ def get_bootpt_cfg(cfg, enabled=False, fstype=None, root_fstype=None):
     #   label:  filesystem label (default to 'boot')
     # parm enable can enable, but not disable
     # parm fstype overrides cfg['fstype']
-    def_boot = (platform.machine() in ('aarch64') and
+    def_boot = (platform.machine() in ['aarch64'] and
                 not util.is_uefi_bootable())
     ret = {'enabled': def_boot, 'fstype': None, 'label': 'boot'}
     ret.update(cfg)

--- a/curtin/commands/block_meta.py
+++ b/curtin/commands/block_meta.py
@@ -199,7 +199,7 @@ def get_bootpt_cfg(cfg, enabled=False, fstype=None, root_fstype=None):
     #   label:  filesystem label (default to 'boot')
     # parm enable can enable, but not disable
     # parm fstype overrides cfg['fstype']
-    def_boot = (platform.machine() in ['aarch64'] and
+    def_boot = (platform.machine() == 'aarch64' and
                 not util.is_uefi_bootable())
     ret = {'enabled': def_boot, 'fstype': None, 'label': 'boot'}
     ret.update(cfg)
@@ -227,7 +227,7 @@ def get_partition_format_type(cfg, machine=None, uefi_bootable=None):
     if uefi_bootable:
         return 'uefi'
 
-    if machine in ['aarch64']:
+    if machine == 'aarch64':
         return 'gpt'
     elif machine.startswith('ppc64'):
         return 'prep'

--- a/curtin/commands/collect_logs.py
+++ b/curtin/commands/collect_logs.py
@@ -154,7 +154,8 @@ def _redact_sensitive_information(target_dir, redact_values):
             with open(fpath) as stream:
                 content = stream.read()
             for redact_value in redact_values:
-                content = re.sub(redact_value, '<REDACTED>', content)
+                content = re.sub(re.escape(redact_value), '<REDACTED>',
+                                 content)
             util.write_file(fpath, content, mode=0o666)
 
 

--- a/curtin/reporter/legacy/maas.py
+++ b/curtin/reporter/legacy/maas.py
@@ -117,7 +117,7 @@ class MAASReporter(BaseReporter):
 
     def _random_string(self, length):
         return ''.join(random.choice(string.ascii_letters)
-                       for ii in range(length + 1))
+                       for ii in range(length))
 
     def _get_content_type(self, filename):
         return mimetypes.guess_type(filename)[0] or 'application/octet-stream'

--- a/tests/unittests/test_collect_logs.py
+++ b/tests/unittests/test_collect_logs.py
@@ -1,0 +1,61 @@
+# This file is part of curtin. See LICENSE file for copyright and license info.
+
+from pathlib import Path
+
+from .helpers import CiTestCase
+from curtin.commands import collect_logs
+
+
+class TestRedactSensitiveInformation(CiTestCase):
+
+    def setUp(self):
+        super().setUp()
+        self.tmpd = Path(self.tmp_dir())
+
+    def _write_file(self, name, content):
+        fpath = self.tmpd / name
+        fpath.write_text(content)
+        return fpath
+
+    def test_redact_simple_value(self):
+        secret = "my-secret-token"
+        fpath = self._write_file("log.txt", f"token: {secret}")
+        collect_logs._redact_sensitive_information(str(self.tmpd), [secret])
+        self.assertEqual("token: <REDACTED>", fpath.read_text())
+
+    def test_redact_dot_treated_as_literal(self):
+        secret = "my.secret"
+        fpath = self._write_file(
+            "log.txt",
+            "my.secret: 1\nmyXsecret: 2",
+        )
+        collect_logs._redact_sensitive_information(str(self.tmpd), [secret])
+        self.assertEqual(
+            "<REDACTED>: 1\nmyXsecret: 2",
+            fpath.read_text(),
+        )
+
+    def test_redact_invalid_regex_does_not_raise(self):
+        secret = "foo[bar"
+        fpath = self._write_file("log.txt", "value: foo[bar")
+        collect_logs._redact_sensitive_information(str(self.tmpd), [secret])
+        self.assertEqual("value: <REDACTED>", fpath.read_text())
+
+    def test_redact_multiple_values(self):
+        secrets = ["token-1", "token-2"]
+        fpath = self._write_file(
+            "log.txt",
+            "first: token-1\nsecond: token-2",
+        )
+        collect_logs._redact_sensitive_information(str(self.tmpd), secrets)
+        self.assertEqual(
+            "first: <REDACTED>\nsecond: <REDACTED>",
+            fpath.read_text(),
+        )
+
+    def test_redact_value_not_present(self):
+        secret = "missing-token"
+        content = "nothing to see here"
+        fpath = self._write_file("log.txt", content)
+        collect_logs._redact_sensitive_information(str(self.tmpd), [secret])
+        self.assertEqual(content, fpath.read_text())


### PR DESCRIPTION
The `re.escape` (or lack of) can cause much pain if secrets contain enough metacharacters.