### PR TITLE
block-meta: add btrfs filesystem resize support

### DIFF
--- a/curtin/commands/block_meta_v2.py
+++ b/curtin/commands/block_meta_v2.py
@@ -1,6 +1,7 @@
 # This file is part of curtin. See LICENSE file for copyright and license info.
 
 import os
+import tempfile
 from typing import (
     List,
     Optional,
@@ -100,6 +101,18 @@ def align_down(size, block_size):
     return size & ~(block_size - 1)
 
 
+def resize_btrfs(path, size):
+    # btrfs filesystem resize requires a mount point, not a raw device.
+    # See https://btrfs.readthedocs.io/en/latest/btrfs-filesystem.html
+    # (filesystem resize). Offline resize only supports increasing the
+    # size for now.
+    # Device id 1 is the default for single-device filesystems.
+    with tempfile.TemporaryDirectory(prefix='curtin-btrfs-') as mountpoint:
+        with util.mount(path, mountpoint):
+            util.subp(['btrfs', 'filesystem', 'resize',
+                       '1:{}'.format(size), mountpoint])
+
+
 def resize_ext(path, size):
     util.subp(['e2fsck', '-p', '-f', path])
     size_k = size // 1024
@@ -123,6 +136,7 @@ def perform_resize(kname, resize):
 
 
 resizers = {
+    'btrfs': resize_btrfs,
     'ext2': resize_ext,
     'ext3': resize_ext,
     'ext4': resize_ext,

--- a/curtin/commands/block_meta_v2.py
+++ b/curtin/commands/block_meta_v2.py
@@ -1,6 +1,7 @@
 # This file is part of curtin. See LICENSE file for copyright and license info.
 
 import os
+import re
 import tempfile
 from typing import (
     List,
@@ -101,16 +102,37 @@ def align_down(size, block_size):
     return size & ~(block_size - 1)
 
 
+def btrfs_device_count(path):
+    # num_devices is read from the superblock, so this works on an unmounted
+    # device without the other members present.
+    out, _ = util.subp(
+        ['btrfs', 'inspect-internal', 'dump-super', '--', path], capture=True)
+    for line in out.splitlines():
+        m = re.fullmatch(r'num_devices\s+(\d+)', line.strip())
+        if m:
+            return int(m.group(1))
+    raise RuntimeError('could not determine btrfs device count for %s' % path)
+
+
 def resize_btrfs(path, size):
     # btrfs filesystem resize requires a mount point, not a raw device.
     # See https://btrfs.readthedocs.io/en/latest/btrfs-filesystem.html
     # (filesystem resize). Offline resize only supports increasing the
     # size for now.
-    # Device id 1 is the default for single-device filesystems.
+    # Device id 1 is the default for single-device filesystems. Refuse
+    # multi-device filesystems rather than resizing the wrong device.
+    btrfs_device_id = 1
+    count = btrfs_device_count(path)
+    if count != btrfs_device_id:
+        raise RuntimeError(
+            'cannot resize multi-device btrfs filesystem on %s '
+            '(found %d devices)' % (path, count))
     with tempfile.TemporaryDirectory(prefix='curtin-btrfs-') as mountpoint:
         with util.mount(path, mountpoint):
             util.subp(['btrfs', 'filesystem', 'resize',
-                       '1:{}'.format(size), mountpoint])
+                       '{devid}:{size}'.format(
+                            devid=btrfs_device_id, size=size),
+                       mountpoint])
 
 
 def resize_ext(path, size):

--- a/doc/topics/storage.rst
+++ b/doc/topics/storage.rst
@@ -479,7 +479,7 @@ If the ``preserve`` flag is set to true, curtin will adjust the size of the
 partition to the new size.  When adjusting smaller, the size of the contents
 must permit that.  When adjusting larger, there must already be a gap beyond
 the partition in question.
-Resize is supported on filesystems of types ext2, ext3, ext4, ntfs.
+Resize is supported on filesystems of types btrfs, ext2, ext3, ext4, ntfs.
 
 **name**: *<name>*
 

--- a/tests/integration/test_block_meta.py
+++ b/tests/integration/test_block_meta.py
@@ -71,7 +71,7 @@ def _get_btrfs_size(dev, part_action):
     out = util.subp(cmd, capture=True)[0]
     # Sample output:
     # dev_item.total_bytes	419430400
-    volsize_matcher = re.compile(r'dev_item\.total_bytes\s+(\d+)\s*')
+    volsize_matcher = re.compile(r'dev_item\.total_bytes\s+(\d+)')
     for line in out.splitlines():
         m = volsize_matcher.fullmatch(line)
         if m:

--- a/tests/integration/test_block_meta.py
+++ b/tests/integration/test_block_meta.py
@@ -65,6 +65,20 @@ class PartData:
         return True
 
 
+def _get_btrfs_size(dev, part_action):
+    num = part_action['number']
+    cmd = ['btrfs', 'inspect-internal', 'dump-super', '--', f'{dev}p{num}']
+    out = util.subp(cmd, capture=True)[0]
+    # Sample output:
+    # dev_item.total_bytes	419430400
+    volsize_matcher = re.compile(r'dev_item\.total_bytes\s+(\d+)\s*')
+    for line in out.splitlines():
+        m = volsize_matcher.fullmatch(line)
+        if m:
+            return int(m.group(1))
+    raise Exception('btrfs volume size not found')
+
+
 def _get_ext_size(dev, part_action):
     num = part_action['number']
     cmd = ['dumpe2fs', '-h', f'{dev}p{num}']
@@ -95,6 +109,7 @@ def _get_ntfs_size(dev, part_action):
 
 
 _get_fs_sizers = {
+    'btrfs': _get_btrfs_size,
     'ext2': _get_ext_size,
     'ext3': _get_ext_size,
     'ext4': _get_ext_size,
@@ -656,12 +671,12 @@ subprocess.run(cmd, env=env)
         finally:
             server.stop()
 
-    def _do_test_resize(self, start, end, fstype):
+    def _do_test_resize(self, start, end, fstype, image_size='200M'):
         start <<= 20
         end <<= 20
         img = self.tmp_path('image.img')
         config = StorageConfigBuilder(version=2)
-        config.add_image(path=img, size='200M', ptable='gpt')
+        config.add_image(path=img, size=image_size, ptable='gpt')
         p1 = config.add_part(size=start, offset=1 << 20, number=1,
                              fstype=fstype)
         self.run_bm(config.render())
@@ -712,6 +727,14 @@ subprocess.run(cmd, env=env)
 
         size_to(160 << 20)
         size_to(140 << 20)
+
+    def test_resize_up_btrfs(self):
+        # btrfs needs more headroom than ext/ntfs; a 250MiB device was
+        # rejected by mkfs.btrfs as too small on 24.04, so keep above that.
+        self._do_test_resize(300, 370, 'btrfs', image_size='400M')
+
+    def test_resize_down_btrfs(self):
+        self._do_test_resize(370, 300, 'btrfs', image_size='400M')
 
     def test_resize_up_ext2(self):
         self._do_test_resize(40, 80, 'ext2')

--- a/tests/unittests/test_commands_block_meta.py
+++ b/tests/unittests/test_commands_block_meta.py
@@ -13,6 +13,7 @@ import os
 import random
 import uuid
 
+from parameterized import parameterized
 from curtin.block import dasd
 from curtin.commands import block_meta, block_meta_v2
 from curtin import paths, util
@@ -3791,14 +3792,19 @@ class TestPartitionNeedsResize(CiTestCase):
         self.table = Mock()
         self.table.sectors2bytes = lambda x: x * 512
 
-    def test_partition_resize_happy_path(self):
+    @parameterized.expand(
+        (
+            ["ext4"], ["btrfs"], ["ntfs"],
+        ),
+    )
+    def test_partition_resize_happy_path(self, fstype):
         self.partition['preserve'] = True
         self.partition['resize'] = True
         self.format['preserve'] = True
-        self.format['fstype'] = 'ext4'
-        self.m_get_volume_fstype.return_value = 'ext4'
+        self.format['fstype'] = fstype
+        self.m_get_volume_fstype.return_value = fstype
         expected = {
-            'fstype': 'ext4',
+            'fstype': fstype,
             'size': 5 << 30,
             'direction': 'up',
         }

--- a/tests/unittests/test_commands_block_meta.py
+++ b/tests/unittests/test_commands_block_meta.py
@@ -3893,6 +3893,16 @@ class TestPartitionNeedsResize(CiTestCase):
                                           self.table, self.sfdisk_part_info))
 
 
+class TestResizeBtrfs(CiTestCase):
+
+    @patch('curtin.commands.block_meta_v2.util.subp')
+    def test_resize_multi_device_raises(self, m_subp):
+        # A multi-device btrfs must be refused, not resized as devid 1.
+        m_subp.return_value = ('num_devices\t\t2\n', '')
+        with self.assertRaises(RuntimeError):
+            block_meta_v2.resize_btrfs('/dev/sda1', 5 << 30)
+
+
 class TestPartitionVerifyFdasd(CiTestCase):
 
     def setUp(self):


### PR DESCRIPTION
## Summary
- Add single-device `btrfs` support to storage-config v2 resizers (`btrfs filesystem resize 1:<size>` via a temporary mount).
- Document btrfs as a supported resize filesystem type.
- Add integration tests for resize up/down.

## Test plan
- [x] `tox -e py3` in Workshop (1552 passed)
- [x] `pytest tests/integration/test_block_meta.py -k btrfs` on LXD Ubuntu 24.04 VM
