### PR TITLE
util: unmount in a finally so mount() cleans up on error

### DIFF
--- a/curtin/util.py
+++ b/curtin/util.py
@@ -558,8 +558,10 @@ def chdir(dirname):
 @contextmanager
 def mount(src, target):
     do_mount(src, target)
-    yield
-    do_umount(target)
+    try:
+        yield
+    finally:
+        do_umount(target)
 
 
 def do_mount(src, target, opts=None):

--- a/tests/unittests/test_util.py
+++ b/tests/unittests/test_util.py
@@ -700,6 +700,28 @@ class TestChrootableTargetMounts(CiTestCase):
         self.assertEqual(sorted(my_mounts), sorted(in_chroot.mounts))
 
 
+class TestMount(CiTestCase):
+    """Test util.mount context manager unmounts target."""
+
+    def setUp(self):
+        super(TestMount, self).setUp()
+        self.add_patch('curtin.util.do_mount', 'm_do_mount')
+        self.add_patch('curtin.util.do_umount', 'm_do_umount')
+
+    def test_mount_umounts_on_success(self):
+        with util.mount('src', 'target'):
+            pass
+        self.m_do_mount.assert_called_once_with('src', 'target')
+        self.m_do_umount.assert_called_once_with('target')
+
+    def test_mount_umounts_on_error(self):
+        with self.assertRaises(RuntimeError):
+            with util.mount('src', 'target'):
+                raise RuntimeError('unexpected error in mount ctx')
+        self.m_do_mount.assert_called_once_with('src', 'target')
+        self.m_do_umount.assert_called_once_with('target')
+
+
 class TestChrootableTargetIsChrootBehavior(CiTestCase):
     """Test ChrootableTargets handle ischroot behavior correctly
 


### PR DESCRIPTION
util.mount() called do_umount() only on the success path. If the body of the "with util.mount(...)" block raised, the filesystem was left mounted. Callers that mount onto a tempfile.TemporaryDirectory then delete the still-mounted directory on cleanup which recurses into the live filesystem (if a filesystem was mounted) and destroys its contents. Wrap the yield in try/finally so the unmount always runs.