### PR TITLE
util: add mount_at_temp_dir context manager

### DIFF
--- a/curtin/commands/block_meta_v2.py
+++ b/curtin/commands/block_meta_v2.py
@@ -2,7 +2,6 @@
 
 import os
 import re
-import tempfile
 from typing import (
     List,
     Optional,
@@ -127,12 +126,11 @@ def resize_btrfs(path, size):
         raise RuntimeError(
             'cannot resize multi-device btrfs filesystem on %s '
             '(found %d devices)' % (path, count))
-    with tempfile.TemporaryDirectory(prefix='curtin-btrfs-') as mountpoint:
-        with util.mount(path, mountpoint):
-            util.subp(['btrfs', 'filesystem', 'resize',
-                       '{devid}:{size}'.format(
-                            devid=btrfs_device_id, size=size),
-                       mountpoint])
+    with util.mount_at_temp_dir(path, prefix='curtin-btrfs-') as mountpoint:
+        util.subp(['btrfs', 'filesystem', 'resize',
+                   '{devid}:{size}'.format(
+                        devid=btrfs_device_id, size=size),
+                   mountpoint])
 
 
 def resize_ext(path, size):

--- a/curtin/util.py
+++ b/curtin/util.py
@@ -564,6 +564,17 @@ def mount(src, target):
         do_umount(target)
 
 
+@contextmanager
+def mount_at_temp_dir(src, prefix='curtin-mnt'):
+    # Mount src at a fresh temporary directory and yield the mountpoint.
+    # mount()'s finally guarantees the unmount runs before the directory
+    # is cleaned up, so callers never need their own TemporaryDirectory
+    # just to have somewhere to mount.
+    with tempfile.TemporaryDirectory(prefix=prefix) as mnt:
+        with mount(src, mnt):
+            yield mnt
+
+
 def do_mount(src, target, opts=None):
     # mount src at target with opts and return True
     # if already mounted, return False

--- a/tests/unittests/test_util.py
+++ b/tests/unittests/test_util.py
@@ -1525,4 +1525,29 @@ VERSION_ID="26.04"
             }
         )
 
+
+class TestMountAtTempDir(CiTestCase):
+
+    @mock.patch('curtin.util.do_umount')
+    @mock.patch('curtin.util.do_mount')
+    def test_mounts_and_yields_mountpoint(self, m_mount, m_umount):
+        with util.mount_at_temp_dir('/dev/sda1') as mnt:
+            self.assertTrue(mnt.startswith('/tmp/'))
+            self.assertTrue(os.path.isdir(mnt))
+            m_mount.assert_called_once_with('/dev/sda1', mnt)
+            m_umount.assert_not_called()
+        m_umount.assert_called_once_with(mnt)
+        self.assertFalse(os.path.exists(mnt))
+
+    @mock.patch('curtin.util.do_umount')
+    @mock.patch('curtin.util.do_mount')
+    def test_unmounts_when_body_raises(self, m_mount, m_umount):
+        mnt_point = None
+        with self.assertRaises(RuntimeError):
+            with util.mount_at_temp_dir('/dev/sda1') as mnt:
+                mnt_point = mnt
+                raise RuntimeError()
+        m_umount.assert_called_once_with(mnt_point)
+
+
 # vi: ts=4 expandtab syntax=python


### PR DESCRIPTION
The pattern of creating a TemporaryDirectory just to have somewhere to mount a filesystem, stacked with util.mount(), recurs in several places and is easy to get subtly wrong (e.g. cleanup ordering: deleting a still-mounted temp directory recurses into the live filesystem).

```python
with tempfile.TemporaryDirectory(prefix=P) as mnt:
    with util.mount(path, mnt):
        ...
```

This wraps it in a single `util.mount_at_temp_dir(src, prefix='curtin-mnt')` context manager that yields the mountpoint and always unmounts before the directory is removed (guaranteed by mount()'s try/finally from #55).

Two commits:

1. `util: add mount_at_temp_dir context manager` — the helper in curtin/util.py plus unit tests (TestMountAtTempDir) that run the real TemporaryDirectory and only mock do_mount/do_umount, so the cleanup ordering is actually verified.
2. `block: use mount_at_temp_dir in get_root_device` — converts the last hand-rolled mkdtemp/do_mount/do_umount/os.rmdir stack in get_root_device() to the new helper. Mount failures still hit the existing bare except and are swallowed as before; the difference is unmount-then-cleanup ordering is no longer the caller's job.

Full unit suite passes: 1559 passed.